### PR TITLE
Fix the device support for EVG Run Mode

### DIFF
--- a/evgMrmApp/src/devSupport/devEvgSoftSeq.cpp
+++ b/evgMrmApp/src/devSupport/devEvgSoftSeq.cpp
@@ -437,10 +437,10 @@ read_wf_eventCode(waveformRecord* pwf) {
     return ret;
 }
 
-/*returns: (0,2)=>(success,success no convert)*/
+/*returns: (0, !0)=>(success, fail)*/
 static long
 write_mbbo_runMode(mbboRecord* pmbbo) {
-    long ret = 2;
+    long ret = 0;
 
     try {
         evgSoftSeq* seq = (evgSoftSeq*)pmbbo->dpvt;
@@ -460,10 +460,10 @@ write_mbbo_runMode(mbboRecord* pmbbo) {
     return ret;
 }
 
-/*returns: (0,2)=>(success,success no convert)*/
+/*returns: (0, !0)=>(success, fail)*/
 static long
 read_mbbi_runMode(mbbiRecord* pmbbi) {
-    long ret = 2;
+    long ret = 0;
 
     try {
         evgSoftSeq* seq = (evgSoftSeq*)pmbbi->dpvt;

--- a/evgMrmApp/src/devSupport/devEvgSoftSeq.cpp
+++ b/evgMrmApp/src/devSupport/devEvgSoftSeq.cpp
@@ -460,10 +460,10 @@ write_mbbo_runMode(mbboRecord* pmbbo) {
     return ret;
 }
 
-/*returns: (0, !0)=>(success, fail)*/
+/*returns: (0,2)=>(success,success no convert)*/
 static long
 read_mbbi_runMode(mbbiRecord* pmbbi) {
-    long ret = 0;
+    long ret = 2;
 
     try {
         evgSoftSeq* seq = (evgSoftSeq*)pmbbi->dpvt;


### PR DESCRIPTION
By RRM, write_mbbo device support routine returns the following values:
0: Success.
Other: Error.

The default return value for write_mbbo_runMode function is 2, which causes an error to be reported regardless of write operation succeeding or not. Changing the default return value to 0 fixes the issue.

read_mbbi device support routine returns a value of 2 if no conversion is performed, hence it is unchanged.