### PR TITLE
Make POSIX time conversion only after all checks

### DIFF
--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -813,9 +813,6 @@ EVRMRM::convertTS(epicsTimeStamp* ts)
         return false;
     }
 
-    //Link seconds counter is POSIX time
-    ts->secPastEpoch-=POSIX_TIME_AT_EPICS_EPOCH;
-
     // Convert ticks to nanoseconds
     double period=1e9/clockTS(); // in nanoseconds
 
@@ -831,6 +828,9 @@ EVRMRM::convertTS(epicsTimeStamp* ts)
         scanIoRequest(timestampValidChange);
         return false;
     }
+
+    //Link seconds counter is POSIX time
+    ts->secPastEpoch-=POSIX_TIME_AT_EPICS_EPOCH;
 
     return true;
 }


### PR DESCRIPTION
Timestamp seconds value is converted before checks are finished. This can cause lastInvalidTimestamp to hold converted value and result in inconsistent comparison later on.