### PR TITLE
Disable sequencer before syncing

### DIFF
--- a/evgMrmApp/src/evgSequencer/evgSoftSeq.cpp
+++ b/evgMrmApp/src/evgSequencer/evgSoftSeq.cpp
@@ -503,13 +503,13 @@ evgSoftSeq::process_eos()
 {
     incNumOfRuns();
 
-    if(isLoaded() && !m_isSynced)
-        finishSync();
-
     // In single shot mode, auto-disable after
     // each run.
     if(m_runModeCt==Single && m_isEnabled)
         disable();
+
+    if(isLoaded() && !m_isSynced)
+        finishSync();
 
     scanIoRequest(iorunscan);
 }

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -657,13 +657,15 @@ EVRMRM::clockTS() const
     //Note: acquires evrLock 3 times.
 
     TSSource src=SourceTS();
+    double eclk=clock();
 
-    if(src!=TSSourceInternal)
+    if( (src!=TSSourceInternal) ||
+       ((src==TSSourceInternal) && (stampClock>eclk)))
         return stampClock;
 
     epicsUInt16 div=tsDiv();
 
-    return clock()/div;
+    return eclk/div;
 }
 
 void
@@ -675,7 +677,7 @@ EVRMRM::clockTSSet(double clk)
     TSSource src=SourceTS();
     double eclk=clock();
 
-    if(clk>eclk || clk==0.0)
+    if(clk>eclk*1.01 || clk==0.0)
         clk=eclk;
 
     SCOPED_LOCK(evrLock);


### PR DESCRIPTION
There is an issue when performing a Commit operation on an Enabled, Loaded sequencer. Commit sometimes causes the sequencer to run without external trigger. At NSLS-II, this triggers ACMI fault to appear spontaneously when changes are made which require sequencer commit, e.g. changing the target injection bucket. ACMI fault means that certain event does not arrive at expected times. Troubleshooting has shown that this event indeed arrived not when expected.

Testing:

With EVG using FracSyn source, Mxc divider was set to obtain ~0.1 Hz frequency (the glitch occurs at 1 Hz as well, but at much lower rate). Sequencer table containing event 25 with timestamp 14 (and other events) was used and assigned to trigger from Mxc in Single Run mode. To rearm the sequencer, single shot controller logic was used which re-enabled the sequencer once its status became Disabled.

Two python scripts were used to provoke and track the glitch: first printed out the time difference between subsequent arrivals of event 25. Second one invalidated the sequencer configuration by switching and restoring the trigger source parameter and performed a commit on arrival of event 25.

Expected behavior is when event 25 arrives every 10 seconds. Observed behavior (output of the first script),  tracking event 25 arrival:

9.277065869 <- Mxc ticks and event 25 arrives, the second script does a commit
0.912279932 <- script sees event 25 again even though Mxc is ~0.1 Hz
0.912262812 <- another spontaneous run, second script performs a commit every time
0.912260970 <- commits keep causing the glitch
0.912296550
0.912276747 <- last spontaneous run, next commit doesn't cause the glitch for some reason
5.627969022 <- Mxc ticks, legitimate event 25 arrival
0.912301377 <- spontaneous runs follow
0.912269223
0.912266949
0.912302002
0.912268566
5.628053982 <- Mxc ticks normally
0.912294509 <- for some reason glitch appears only once
9.277051525 <- Mxc ticks, script commits
0.912281013 <- glitch again
...

It is peculiar that the time it takes for the spontaneous trigger to appear, ~0.91 seconds, corresponds to the last timestamp in the sequencer table, 113856614 ticks * 8 ns = ~0.91 seconds. Changing the timestamp of this last event also causes the spontaneous trigger delay to change. It means that when commit is performed, it sometimes makes sequencer to run immediately after the ongoing sequence is finished. If commit is performed again during the second run, it may cause another spontaneous run and so on.

It was found in code that when in Single mode, sequencer is not disabled before Commit is applied. When proposed fix is in place, the first script output is as follows:

10.189346033
10.189346034
...

i.e. event 25 arrives every ~10 seconds, as expected, and spontaneous sequencer runs are not observed. It is proposed to disable sequencer when needed before applying the commit.