### PR TITLE
Add support for deviceTime

### DIFF
--- a/evgMrmApp/src/devSupport/devEvgMrm.cpp
+++ b/evgMrmApp/src/devSupport/devEvgMrm.cpp
@@ -98,6 +98,9 @@ read_si_ts(stringinRecord* psi) {
 
         switch(evg->m_alarmTimestamp) {
             case TS_ALARM_NONE:
+                if (psi->tsel.type == CONSTANT &&
+                    psi->tse == epicsTimeEventDeviceTime)
+                    psi->time = ts;
                 break;
             case TS_ALARM_MINOR:
                 (void)recGblSetSevr(psi, SOFT_ALARM, MINOR_ALARM);


### PR DESCRIPTION
Allow evgMrm stringin device support to set record's time-stamp.

Does it make sense to only set the time-stamp like this when the evg is in no-alarm status?