### PR TITLE
epicsTypes.h includes to deal with missing epicsUInt type definitions

### DIFF
--- a/evgMrmApp/src/mrmevgseq.cpp
+++ b/evgMrmApp/src/mrmevgseq.cpp
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 
 #include "mrmevgseq.h"

--- a/evrMrmApp/src/drvemCML.cpp
+++ b/evrMrmApp/src/drvemCML.cpp
@@ -14,6 +14,7 @@
 
 #include <epicsMath.h>
 
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 #include <mrfBitOps.h>
 #include "evrRegMap.h"

--- a/evrMrmApp/src/drvemInput.cpp
+++ b/evrMrmApp/src/drvemInput.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <epicsInterrupt.h>
 
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 #include <mrfBitOps.h>
 

--- a/evrMrmApp/src/drvemRxBuf.cpp
+++ b/evrMrmApp/src/drvemRxBuf.cpp
@@ -19,6 +19,7 @@
 	#pragma comment (lib, "Ws2_32.lib")
 #endif
 #include <callback.h>
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 #include <mrfBitOps.h>
 #include <epicsInterrupt.h>

--- a/evrMrmApp/src/mrmevrseq.cpp
+++ b/evrMrmApp/src/mrmevrseq.cpp
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 
 #include "mrmevrseq.h"

--- a/mrmShared/src/mrmSeq.cpp
+++ b/mrmShared/src/mrmSeq.cpp
@@ -14,6 +14,7 @@
 #include <epicsMutex.h>
 #include <errlog.h>
 
+#include <epicsTypes.h>
 #include <mrfCommonIO.h>
 
 #include "mrmSeq.h"


### PR DESCRIPTION
To make the latest version build for RTEMS (on Debian 7 with base 3.14.12.3-6), I have to add several includes to deal with missing type definitions, e.g.:

```
In file included from ../../../include/mrfCommonIO.h:102,
                 from ../mrmSeq.cpp:17:
../../../../devlib2/include/os/RTEMS/epicsMMIO.h:51: error: 'epicsUInt16' does not name a type
../../../../devlib2/include/os/RTEMS/epicsMMIO.h:59: error: 'epicsUInt32' does not name a type
../mrmSeq.cpp:389: warning: 'done_SoftSequence' defined but not used
../mrmSeq.cpp:778: warning: 'done_SeqManager' defined but not used
```

There is evidence that the build is successful with no modifications when using base 3.15.

Furthermore, if building with additional modules (autosave, caputlog, deviocstats), the build fails obscurely, unless DEVLIB2 is moved before all modules in configure/RELEASE. E.g.:

```
../evr.cpp: In member function ‘virtual std::string EVR::position() const’:
../evr.cpp:61:38: error: ‘const struct epicsPCIDevice’ has no member named ‘slot’
../evr.cpp:62:63: error: ‘const struct epicsPCIDevice’ has no member named ‘slot’
../evr.cpp: At global scope:
../evr.cpp:143:1: warning: ‘done_EVR’ defined but not used [-Wunused-variable]
../evr.cpp:162:1: warning: ‘done_Input’ defined but not used [-Wunused-variable]
../evr.cpp:171:1: warning: ‘done_Output’ defined but not used [-Wunused-variable]
../evr.cpp:188:1: warning: ‘done_Pulser’ defined but not used [-Wunused-variable]
../evr.cpp:195:1: warning: ‘done_PreScaler’ defined but not used [-Wunused-variable]
../evr.cpp:240:1: warning: ‘done_CML’ defined but not used [-Wunused-variable]
../evr.cpp:248:1: warning: ‘done_DelayModuleEvr’ defined but not used [-Wunused-variable]
make[3]: *** [evr.o] Error 1
```

Those problems might be remedied by using a newer base, but as long as the source is supposed to build with 3.14...