### PR TITLE
replace the nsls pv style with the genric ones  or  in basis db sources

### DIFF
--- a/evgMrmApp/Db/evgInput.db
+++ b/evgMrmApp/Db/evgInput.db
@@ -5,7 +5,7 @@ record(bo, "$(P)EnaIrq-Sel") {
     field( ZNAM, "Disabled")
     field( ONAM, "Enabled")
     field( OMSL, "closed_loop")
-    field( DOL,  "$(SYS){$(D)}1ppsInp-MbbiDir_.B$(Num) CP")
+    field( DOL , "$(P)1ppsInp-MbbiDir_.B$(Num) CP")
     field( FLNK, "$(P)EnaIrq-RB")
     info( autosaveFields_pass0, "VAL")
 }

--- a/evgMrmApp/Db/evgMxc.db
+++ b/evgMrmApp/Db/evgMxc.db
@@ -68,14 +68,14 @@ record(longin , "$(P)Prescaler-RB") {
     field( DTYP, "Obj Prop uint32")
     field( INP , "@OBJ=$(OBJ), PROP=Prescaler")
     field( DESC, "EVG Mux Prescaler RB")
-    field( FLNK, "$(SYS){$(D)}ResetMxc-Cmd")
+    field( FLNK, "$(P)ResetMxc-Cmd")
 }
 
 #
 # When Evt Clock Frequency changes, Mxc Freq changes keeping the Prescaler same.
 #
 record(ai, "$(P)EvtClkFreq-RB_") {
-    field( INP,  "$(SYS){$(D)-EvtClk}Frequency-RB CP")
+    field( INP,  "$(EVTCLKP)Frequency-RB CP")
     field( FLNK, "$(P)Frequency-RB")
 }
 

--- a/evgMrmApp/Db/evgSoftSeq.template
+++ b/evgMrmApp/Db/evgSoftSeq.template
@@ -94,7 +94,7 @@ record(mbbi, "$(P)TrigSrc-RB") {
 #(only if TsInpMode = EGU).
 #
 record(ai, "$(P)EvtClkFreq-RB_") {
-    field( INP,  "$(SYS){$(D)-EvtClk}Frequency-RB CP")
+    field( INP,  "$(EVTCLKP)Frequency-RB CP")
     field( FLNK, "$(P)EvtClkFreq:Cont-RB_")
 }
 


### PR DESCRIPTION
Michael, 

Please look at the db changes. I tried to check them my best. And let me know what you think. Possibly 
substitutions files should be replaced as follows:

```
file evgMxc.db {
pattern { P, OBJ, EVTCLKP }
....
}
```
```
file evgSoftSeq.template {
pattern { P, EVG, seqNum, NELM , EVTCLKP }
........
}
```
EVTCLKP should be the same as P in
```
 file evgEvtClk.db 
{P=" ...."

```
Note that I didn't change any other evg.substitutions files.