### PR TITLE
FIFO queue delay compensation

### DIFF
--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -13,6 +13,7 @@ DB += sequencedemo.db
 DB += evr-pmc-230.db
 DB += evr-cpci-230.db
 DB += evr-cpci-300.db
+DB += evr-cpci-300dc.db
 DB += evr-vmerf-230.db
 DB += evr-tg-300.db
 DB += evr-mtca-300.db

--- a/evrMrmApp/Db/evr-cpci-300dc.substitutions
+++ b/evrMrmApp/Db/evr-cpci-300dc.substitutions
@@ -1,0 +1,172 @@
+# Record set for a cPCI-EVR-300
+#
+# Macros:
+#  EVR = Card name (same as mrmEvrSetupPCI())
+#  SYS = System name (ie SR-TM)
+#  D = Device name (ie EVR:Diag2)
+#  FEVT = Event link frequency (default 124.916 MHz)
+#
+# Record names have the general forms:
+#  $(SYS){$(D)}Signal-SD
+#  $(SYS){$(D)-SubDev}Signal-SD
+
+file "evrbase.db"
+{
+{P="$(SYS){$(D)}", OBJ="$(EVR)", EVNT1Hz="125", FEVT="\$(FEVT=124.916)"}
+}
+
+file "databuftx.db"
+{pattern
+{P, OBJ, PROTO}
+{"$(SYS){$(D)}", "$(EVR):BUFTX", 1}
+}
+
+file "databuftxCtrl.db"
+{pattern
+{P, OBJ}
+{"$(SYS){$(D)}", "$(EVR):BUFTX"}
+}
+
+file "mrmevrbufrx.db"
+{pattern
+{P, OBJ, PROTO}
+{"$(SYS){$(D)}", $(EVR):BUFRX, 0xff00}
+}
+
+file "sfp.db"
+{
+{P="$(SYS){$(D)-SFP}", OBJ="$(EVR):SFP"}
+}
+
+file "mrmevrdc.template"
+{
+{P="$(SYS){$(D)-DC}", OBJ="$(EVR)"}
+}
+
+file "evrmap.db"
+{pattern
+{NAME, OBJ, func, EVT}
+{"$(SYS){$(D)}Evt:Blink0-SP", "$(EVR)", Blink, 15}
+{"$(SYS){$(D)}Evt:Blink1-SP", "$(EVR)", Blink, 0}
+{"$(SYS){$(D)}Evt:ResetPS-SP","$(EVR)", "Reset PS", 123}
+}
+
+file "evrevent.db"
+{pattern
+{EN, OBJ, CODE, EVNT}
+{"$(SYS){$(D)}1hz",  "$(EVR)", 0x7d, 125}
+{"$(SYS){$(D)}EvtA", "$(EVR)", 10, 10}
+{"$(SYS){$(D)}EvtB", "$(EVR)", 11, 11}
+{"$(SYS){$(D)}EvtC", "$(EVR)", 12, 12}
+{"$(SYS){$(D)}EvtD", "$(EVR)", 13, 13}
+{"$(SYS){$(D)}EvtE", "$(EVR)", 14, 14}
+{"$(SYS){$(D)}EvtF", "$(EVR)", 15, 15}
+{"$(SYS){$(D)}EvtG", "$(EVR)", 16, 16}
+{"$(SYS){$(D)}EvtH", "$(EVR)", 17, 17}
+}
+
+file "evrscale.db"
+{pattern
+{IDX, P, SN, OBJ, MAX}
+{0, "$(SYS){$(D)}", "$(SYS){$(D)-PS:$(IDX)}", "$(EVR):PS$(IDX)", "0xffffffff"}
+{1, "$(SYS){$(D)}", "$(SYS){$(D)-PS:$(IDX)}", "$(EVR):PS$(IDX)", "0xffffffff"}
+{2, "$(SYS){$(D)}", "$(SYS){$(D)-PS:$(IDX)}", "$(EVR):PS$(IDX)", "0xffffffff"}
+}
+
+file "mrmevrout.db"
+{pattern
+{ON, OBJ, DESC}
+{"$(SYS){$(D)-Out:Int}", "$(EVR):Int", "Internal"}
+{"$(SYS){$(D)-Out:FPUV0}", "$(EVR):FrontUnivOut0", "UNIV0"}
+{"$(SYS){$(D)-Out:FPUV1}", "$(EVR):FrontUnivOut1", "UNIV1"}
+{"$(SYS){$(D)-Out:FPUV2}", "$(EVR):FrontUnivOut2", "UNIV2"}
+{"$(SYS){$(D)-Out:FPUV3}", "$(EVR):FrontUnivOut3", "UNIV3"}
+{"$(SYS){$(D)-Out:FPUV4}", "$(EVR):FrontUnivOut4", "UNIV4"}
+{"$(SYS){$(D)-Out:FPUV5}", "$(EVR):FrontUnivOut5", "UNIV5"}
+{"$(SYS){$(D)-Out:FPUV6}", "$(EVR):FrontUnivOut6", "UNIV6"}
+{"$(SYS){$(D)-Out:FPUV7}", "$(EVR):FrontUnivOut7", "UNIV7"}
+{"$(SYS){$(D)-Out:FPUV8}", "$(EVR):FrontUnivOut8", "UNIV8"}
+{"$(SYS){$(D)-Out:FPUV9}", "$(EVR):FrontUnivOut9", "UNIV9"}
+{"$(SYS){$(D)-Out:FPUV10}","$(EVR):FrontUnivOut10","UNIV10"}
+{"$(SYS){$(D)-Out:FPUV11}","$(EVR):FrontUnivOut11","UNIV11"}
+}
+
+file "mrmevroutint.db"
+{{
+    ON="$(SYS){$(D)-Out:Int}", OBJ="$(EVR)"
+}}
+
+# Pulse generators w/o a prescaler set NOPS=1
+file "evrpulser.db"
+{pattern
+{PID, P, PN, OBJ, DMAX, WMAX, PMAX, NOPS}
+{0, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{5, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{6, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{7, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{8, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{9, "$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{10,"$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffff", "0xffff", "1", 1}
+{11,"$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffff", "0xffff", "1", 1}
+{12,"$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffff", "0xffff", "1", 1}
+{13,"$(SYS){$(D)}", "$(SYS){$(D)-DlyGen:$(PID)}", "$(EVR):Pul$(PID)", "0xffffff", "0xffff", "1", 1}
+}
+
+# Default to 3 possible trigger mappings per pulser
+file "evrpulsermap.db"
+{pattern
+{PID, NAME, OBJ, F, EVT}
+{0, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"$(SYS){$(D)-DlyGen:$(PID)}Evt:Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+}
+
+file "evrin.db"
+{pattern
+{IN, OBJ, DESC}
+{"$(SYS){$(D)-In:0}", "$(EVR):FPIn0", "IN0 (TTL)"}
+{"$(SYS){$(D)-In:1}", "$(EVR):FPIn1", "IN1 (TTL)"}
+}

--- a/evrMrmApp/Db/mrmevrdc.template
+++ b/evrMrmApp/Db/mrmevrdc.template
@@ -27,6 +27,7 @@ record(bo, "$(P):DLY_CMD_INCR") {
     field(ZNAM, "Inactive")
     field(ONAM, "Increase")
     field(HIGH, "0.25")
+    field(FLNK, "$(P):DLY_RSET_TICK")
     info(archive, " ")
 }
 
@@ -37,7 +38,30 @@ record(bo, "$(P):DLY_CMD_DECR") {
     field(ZNAM, "Inactive")
     field(ONAM, "Decrease")
     field(HIGH, "0.25")
+    field(FLNK, "$(P):DLY_RSET_TICK")
     info(archive, " ")
+}
+
+record(longout, "$(P):DLY_CSET_TICK") {
+    field(DESC, "Set delay in ticks")
+    field(DTYP, "Obj Prop uint32")
+    field( OUT, "@OBJ=$(OBJ), PROP=DCIntTicks")
+    field( EGU, "Tick")
+}
+
+record(calc, "$(P):DLY_RSET_TICK") {
+    field(DESC, "Req'd full-tick delay")
+    field(INPA, "$(P):DLY_CMD_INCR NPP MS")
+    field(INPB, "$(P):DLY_CMD_DECR NPP MS")
+    field(CALC, "VAL + (A-B)")
+    field(FLNK, "$(P):DLY_RSET_TINT")
+}
+
+record(longin, "$(P):DLY_RSET_TINT") {
+    field(DESC, "Req'd full-tick delay")
+    field(DTYP, "Obj Prop uint32")
+    field(SCAN, "1 second")
+    field( INP, "@OBJ=$(OBJ), PROP=DCIntTicks")
 }
 
 record(bo, "$(P)Ena-Sel") {

--- a/evrMrmApp/Db/mrmevrdc.template
+++ b/evrMrmApp/Db/mrmevrdc.template
@@ -97,6 +97,7 @@ record(ai, "$(P)Corr-I") {
     field(FLNK, "$(P)Lck-Sts")
     info(autosaveFields_pass0, "EGU ESLO HOPR LOPR PREC")
 }
+
 record(bi, "$(P)Lck-Sts") {
     field(DTYP, "Obj Prop uint32")
     field( INP, "@OBJ=$(OBJ), PROP=DCStatusRaw")

--- a/evrMrmApp/Db/mrmevrdc.template
+++ b/evrMrmApp/Db/mrmevrdc.template
@@ -1,5 +1,45 @@
 # Delay Compensation control/status
 
+record(longout, "$(P):DLY_CSET_QPHA") {
+    field(DESC, "Set fractional delay")
+    field(DTYP, "Obj Prop uint32")
+    field( OUT, "@OBJ=$(OBJ), PROP=ECP3DPhase")
+    field(EGU, "cycles/16")
+    field(DRVH, "15")
+    field(DRVL, "0")
+    field(FLNK, "$(P):DLY_RSET_QPHA")
+    info(archive, " ")
+    info(autosaveFields_pass0, "VAL")
+}
+
+record(longin, "$(P):DLY_RSET_QPHA") {
+    field(DESC, "Get fractional delay")
+    field(DTYP, "Obj Prop uint32")
+    field(INP, "@OBJ=$(OBJ), PROP=ECP3DPhase")
+    field(EGU, "cycles/16")
+    info(archive, " ")
+}
+
+record(bo, "$(P):DLY_CMD_INCR") {
+    field(DESC, "Increase Delay 1 cycle")
+    field(DTYP, "Obj Prop bool")
+    field( OUT, "@OBJ=$(OBJ), PROP=ECP3DINC")
+    field(ZNAM, "Inactive")
+    field(ONAM, "Increase")
+    field(HIGH, "0.25")
+    info(archive, " ")
+}
+
+record(bo, "$(P):DLY_CMD_DECR") {
+    field(DESC, "Decrease Delay 1 cycle")
+    field(DTYP, "Obj Prop bool")
+    field( OUT, "@OBJ=$(OBJ), PROP=ECP3DDEC")
+    field(ZNAM, "Inactive")
+    field(ONAM, "Decrease")
+    field(HIGH, "0.25")
+    info(archive, " ")
+}
+
 record(bo, "$(P)Ena-Sel") {
     field(DESC, "Apply DC correction")
     field(DTYP, "Obj Prop bool")

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1054,6 +1054,43 @@ EVRMRM::topId() const
     return READ32(base, TOPID);
 }
 
+epicsUInt32
+EVRMRM::ECP3DelayRaw() const
+{
+    return READ32(base, ECP3Delay_control);
+}
+
+epicsUInt32
+EVRMRM::ECP3DPhase() const
+{
+    return (ECP3DelayRaw() & ECP3Delay_DPHASE) >> ECP3Delay_shift;
+}
+
+void
+EVRMRM::setECP3DPhase(epicsUInt32 steps)
+{
+    SCOPED_LOCK(evrLock);
+    if (steps < 0) steps = 0;
+    else if (steps > 15) steps = 15;
+    WRITE32(base, ECP3Delay_control, (ECP3DelayRaw() & ~(ECP3Delay_DPHASE)) | (steps << ECP3Delay_shift));
+}
+
+void
+EVRMRM::ECP3DelayIncrease(bool i)
+{
+    SCOPED_LOCK(evrLock);
+    if(i)
+        BITSET32(base, ECP3Delay_control, ECP3Delay_DINC);
+}
+
+void
+EVRMRM::ECP3DelayDecrease(bool d)
+{
+    SCOPED_LOCK(evrLock);
+    if(d)
+        BITSET32(base, ECP3Delay_control, ECP3Delay_DDEC);
+}
+
 void
 EVRMRM::setEvtCode(epicsUInt32 code)
 {
@@ -1111,6 +1148,10 @@ OBJECT_BEGIN2(EVRMRM, EVR)
   OBJECT_PROP1("DCInt",    &EVRMRM::dcInternal);
   OBJECT_PROP1("DCStatusRaw", &EVRMRM::dcStatusRaw);
   OBJECT_PROP1("DCTOPID", &EVRMRM::topId);
+  OBJECT_PROP1("ECP3DelayRaw", &EVRMRM::ECP3DelayRaw);
+  OBJECT_PROP2("ECP3DPhase", &EVRMRM::ECP3DPhase, &EVRMRM::setECP3DPhase);
+  OBJECT_PROP2("ECP3DINC", &EVRMRM::dummyBool, &EVRMRM::ECP3DelayIncrease);
+  OBJECT_PROP2("ECP3DDEC", &EVRMRM::dummyBool, &EVRMRM::ECP3DelayDecrease);
   OBJECT_PROP2("EvtCode", &EVRMRM::dummy, &EVRMRM::setEvtCode);
   OBJECT_PROP2("TimeSrc", &EVRMRM::timeSrc, &EVRMRM::setTimeSrc);
     {

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -199,6 +199,8 @@ public:
     double dcRx() const;
     //! Delay compensation applied
     double dcInternal() const;
+    void setFIFODelay(epicsUInt32);
+    epicsUInt32 dcIntTicks() const;
     epicsUInt32 dcStatusRaw() const;
     epicsUInt32 topId() const;
 

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -202,6 +202,16 @@ public:
     epicsUInt32 dcStatusRaw() const;
     epicsUInt32 topId() const;
 
+    //! Read raw delay register
+    epicsUInt32 ECP3DelayRaw() const;
+    //! Phase between FIFO Read/Write clocks in 16ths of a cycle
+    epicsUInt32 ECP3DPhase() const;
+    void setECP3DPhase(epicsUInt32);
+    //! Increment/Decrement delay by 1 whole cycle
+    bool dummyBool() const {return false;}
+    void ECP3DelayIncrease(bool i);
+    void ECP3DelayDecrease(bool d);
+
     epicsUInt32 dummy() const { return 0; }
     void setEvtCode(epicsUInt32 code) OVERRIDE FINAL;
 

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -186,6 +186,14 @@
 #define U32_DCStatus    0x0bc
 #define U32_TOPID       0x0c0
 
+#define U32_ECP3Delay_control 0x0c4
+  #define ECP3Delay_DINC   0x80000000
+  #define ECP3Delay_DDEC   0x40000000
+  #define ECP3Delay_DPHASE 0x00000F00
+    #define ECP3Delay_shift  0x00000008
+  #define ECP3Delay_FDELB  0x00000016
+  #define ECP3Delay_FDELA  0x00000001
+
 #define  U32_SeqControl_base    0x00e0
 #define  U32_SeqControl(n)      (U32_SeqControl_base + (4*n))
 


### PR DESCRIPTION
Here is some rough support for software delay compensation on our cPCI EVR units (new in FW version 1402000b). Documentation of this functionality detailed here: [cPCI-FIFO.pdf](https://github.com/epics-modules/mrfioc2/files/2980403/cPCI-FIFO.pdf)

Of particular note is drvem.cpp line 1075. Is there a macro/better way to manipulate 4 bits in a 32-bit register? Any suggestions welcome.