### PR TITLE
clear sumerr in event of error while draining buffer

### DIFF
--- a/evrMrmApp/src/drvemRxBuf.cpp
+++ b/evrMrmApp/src/drvemRxBuf.cpp
@@ -89,6 +89,7 @@ try {
         return;
 
     if (sts&DataBufCtrl_sumerr) {
+        BITSET(NAT,32,self.base,DataBufCtrl,DataBufCtrl_sumerr);
         self.haderror(2);
 
     } else {


### PR DESCRIPTION
After adding this line, I attempted to reproduce the problem (#19)  20+ times and was unable to. 