### PR TITLE
RFC: prescaler phase offset & pulse triggering

### DIFF
--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -36,3 +36,43 @@ record(waveform, "$(SN)Label-I") {
   field(NELM, "128")
   info(autosaveFields_pass1, "VAL")
 }
+
+record(longout, "$(SN)PhasOffs-SP") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( OUT , "@OBJ=$(OBJ), PROP=Phase Offset")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "0xffffffff")
+  field( LOPR, "0")
+  field( DRVH, "0xffffffff")
+  field( DRVL, "0")
+  field( FLNK, "$(SN)PhasOffs-RB")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(longin, "$(SN)PhasOffs-RB") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( INP , "@OBJ=$(OBJ), PROP=Phase Offset")
+}
+
+record(longout, "$(SN)PulsTrig-SP") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Pulse Trig")
+  field( OUT , "@OBJ=$(OBJ), PROP=Pulse Trig")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "0xffff")
+  field( LOPR, "0")
+  field( DRVH, "0xffff")
+  field( DRVL, "0")
+  field( FLNK, "$(SN)PulsTrig-RB")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(longin, "$(SN)PulsTrig-RB") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Pulse Trig")
+  field( INP , "@OBJ=$(OBJ), PROP=Pulse Trig")
+}

--- a/evrApp/src/evr.cpp
+++ b/evrApp/src/evr.cpp
@@ -192,6 +192,10 @@ OBJECT_BEGIN(PreScaler) {
 
     OBJECT_PROP2("Divide", &PreScaler::prescaler, &PreScaler::setPrescaler);
 
+    OBJECT_PROP2("Phase Offset", &PreScaler::prescalerPhasOffs, &PreScaler::setPrescalerPhasOffs);
+
+    OBJECT_PROP2("Pulse Trig", &PreScaler::prescalerPulsTrig, &PreScaler::setPrescalerPulsTrig);
+
 } OBJECT_END(PreScaler)
 
 

--- a/evrApp/src/evr/prescaler.h
+++ b/evrApp/src/evr/prescaler.h
@@ -26,6 +26,12 @@ public:
   virtual epicsUInt32 prescaler() const=0;
   virtual void setPrescaler(epicsUInt32)=0;
 
+  virtual epicsUInt32 prescalerPhasOffs() const { return 0; };
+  virtual void setPrescalerPhasOffs(epicsUInt32) { };
+
+  virtual epicsUInt32 prescalerPulsTrig() const { return 0; };
+  virtual void setPrescalerPulsTrig(epicsUInt32) { };
+
   EVR& owner;
 };
 

--- a/evrMrmApp/src/drvemPrescaler.cpp
+++ b/evrMrmApp/src/drvemPrescaler.cpp
@@ -31,3 +31,27 @@ MRMPreScaler::setPrescaler(epicsUInt32 v)
 {
     nat_iowrite32(base, v);
 }
+
+epicsUInt32
+MRMPreScaler::prescalerPhasOffs() const
+{
+    return nat_ioread32(base + ScalerPhasOffs_offset);
+}
+
+void
+MRMPreScaler::setPrescalerPhasOffs(epicsUInt32 v)
+{
+    nat_iowrite32(base + ScalerPhasOffs_offset, v);
+}
+
+epicsUInt32
+MRMPreScaler::prescalerPulsTrig() const
+{
+    return nat_ioread32(base + ScalerPulsTrig_offset);
+}
+
+void
+MRMPreScaler::setPrescalerPulsTrig(epicsUInt32 v)
+{
+    nat_iowrite32(base + ScalerPulsTrig_offset, v);
+}

--- a/evrMrmApp/src/drvemPrescaler.h
+++ b/evrMrmApp/src/drvemPrescaler.h
@@ -28,6 +28,12 @@ public:
 
     virtual epicsUInt32 prescaler() const;
     virtual void setPrescaler(epicsUInt32);
+
+    virtual epicsUInt32 prescalerPhasOffs() const;
+    virtual void setPrescalerPhasOffs(epicsUInt32);
+
+    virtual epicsUInt32 prescalerPulsTrig() const;
+    virtual void setPrescalerPulsTrig(epicsUInt32);
 };
 
 #endif // MRMEVRPRESCALER_H_INC

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -190,6 +190,8 @@
 #  define ScalerMax 3
 /* 0 <= N <= 2 */
 #define U32_Scaler(N)   (U32_ScalerN + (4*(N)))
+#  define ScalerPhasOffs_offset 0x20
+#  define ScalerPulsTrig_offset 0x40
 
 #define U32_PulserNCtrl 0x200
 #define U32_PulserNScal 0x204


### PR DESCRIPTION
Tested on mtca EVR.

I am not sure about using fixed register offsets in drvemPrescaler.cpp,
because MRMPreScaler class maybe avoids it to be hardware generic.

Another way would be to use MRMPreScaler like this:
MRMPreScaler(name.str(), *this,i);
instead of like this:
MRMPreScaler(name.str(), *this,base+U32_Scaler(i));

So register #defines would be used only within the class.