### PR TITLE
fix datasheet mismatch

### DIFF
--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -348,7 +348,7 @@
 #define MappingRamBlockSet       0x8
 #define MappingRamBlockReset     0xc
 
-#define U32__MappingRam(M,E,N) (U32_MappingRam_base + (0x2000*(M)) + (0x10*(E)) + (N))
+#define U32__MappingRam(M,E,N) (U32_MappingRam_base + (0x1000*(M)) + (0x10*(E)) + (N))
 #define U32_MappingRam(M,E,N) U32__MappingRam(M,E, MappingRamBlock##N)
 
 // MappingRam actions


### PR DESCRIPTION
June 19 datasheet shows offset difference between MapRam1 and MapRam2 is 0x1000 not 0x2000