### PR TITLE
Add enable-gate functionality.

### DIFF
--- a/evrMrmApp/Db/evrdcpulser.template
+++ b/evrMrmApp/Db/evrdcpulser.template
@@ -15,3 +15,21 @@ record(mbbiDirect, "$(PN)Mask-RB") {
   field(NOBT, "4")
   info(autosaveFields_pass0, "RVAL")
 }
+
+record(mbboDirect, "$(PN)EnableGate-Sel") {
+  field(DTYP, "Obj Prop uint32")
+  field(OUT , "@OBJ=$(OBJ), PROP=Enables")
+  field(PINI, "YES")
+  field(NOBT, "4")
+  field(VAL , "0")
+  field(FLNK, "$(PN)EnableGate-RB")
+  info(autosaveFields_pass0, "RVAL")
+}
+
+record(mbbiDirect, "$(PN)EnableGate-RB") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP , "@OBJ=$(OBJ), PROP=Enables")
+  field(PINI, "YES")
+  field(NOBT, "4")
+  info(autosaveFields_pass0, "RVAL")
+}

--- a/evrMrmApp/src/drvemPulser.cpp
+++ b/evrMrmApp/src/drvemPulser.cpp
@@ -153,6 +153,28 @@ MRMPulser::setPolarityInvert(bool s)
         BITCLR(NAT,32,owner.base, PulserCtrl(id), PulserCtrl_pol);
 }
 
+epicsUInt32 MRMPulser::enables() const
+{
+    return (READ32(owner.base, PulserCtrl(id)) & PulserCtrl_enables)>>PulserCtrl_enables_shift;
+}
+
+void MRMPulser::setEnables(epicsUInt32 inps)
+{
+    epicsUInt32 reg = READ32(owner.base, PulserCtrl(id));
+
+    inps <<= PulserCtrl_enables_shift;
+    inps &= PulserCtrl_enables;
+
+    reg &= ~(PulserCtrl_enables);
+
+    WRITE32(owner.base, PulserCtrl(id), reg|inps);
+
+    epicsUInt32 rereg = READ32(owner.base, PulserCtrl(id));
+
+    if((rereg&PulserCtrl_enables)!=inps)
+        throw std::runtime_error("FW doesn't support Pulser enable-gates");
+}
+
 epicsUInt32 MRMPulser::masks() const
 {
     return (READ32(owner.base, PulserCtrl(id)) & PulserCtrl_masks)>>PulserCtrl_masks_shift;
@@ -256,4 +278,5 @@ MRMPulser::sourceSetMap(epicsUInt32 evt,MapType::type action)
 
 OBJECT_BEGIN2(MRMPulser, Pulser)
     OBJECT_PROP2("Masks", &MRMPulser::masks, &MRMPulser::setMasks);
+    OBJECT_PROP2("Enables", &MRMPulser::enables, &MRMPulser::setEnables);
 OBJECT_END(MRMPulser)

--- a/evrMrmApp/src/drvemPulser.h
+++ b/evrMrmApp/src/drvemPulser.h
@@ -49,6 +49,8 @@ public:
     virtual bool polarityInvert() const;
     virtual void setPolarityInvert(bool);
 
+    epicsUInt32 enables() const;
+    void setEnables(epicsUInt32 inps);
     epicsUInt32 masks() const;
     void setMasks(epicsUInt32 inps);
 


### PR DESCRIPTION
A copy paste from current mask-gates routines.
Successfully tested on
	FPGA version: 280b0207
	mTCA-EVM-300 #Inputs FP:3 UV:16 RB:0