### PR TITLE
RFC: add EVR Phase Offset functionality

### DIFF
--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -43,3 +43,52 @@ record(waveform, "$(SN)Label-I") {
   field(NELM, "128")
   info(autosaveFields_pass1, "VAL")
 }
+
+record(ao, "$(SN)PhasOffs-SP") {
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( EGU , "Deg")
+  field( OMSL, "supervisory")
+  field( HOPR, "359.9999999999")
+  field( LOPR, "0")
+  field( DRVH, "359.9999999999")
+  field( DRVL, "0")
+  field( FLNK, "$(SN)PhasOffs-CO_")
+}
+
+record(calcout, "$(SN)PhasOffs-CO_") {
+  field( DESC, "Degrees to Event Clock Ticks")
+  field( OUT , "$(SN)PhasOffs:Raw-SP PP")
+  field( CALC, "FLOOR(B/360*A)")
+  field( INPA, "$(SN)Div-RB CPP")
+  field( INPB, "$(SN)PhasOffs-SP")
+}
+
+record(longout, "$(SN)PhasOffs:Raw-SP") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( OUT , "@OBJ=$(OBJ), PROP=Phase Offset")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "0xffffffff")
+  field( LOPR, "0")
+  field( DRVH, "0xffffffff")
+  field( DRVL, "0")
+  field( FLNK, "$(SN)PhasOffs:Raw-RB")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(longin, "$(SN)PhasOffs:Raw-RB") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( INP , "@OBJ=$(OBJ), PROP=Phase Offset")
+  field( PINI, "YES")
+  field( FLNK, "$(SN)PhasOffs-RB")
+}
+
+record(calc, "$(SN)PhasOffs-RB") {
+  field( DESC, "Prescaler $(IDX) Phase Offset")
+  field( CALC, "B/A*360")
+  field( EGU , "Deg")
+  field( INPA, "$(SN)Div-RB")
+  field( INPB, "$(SN)PhasOffs:Raw-RB PP")
+}

--- a/evrApp/src/evr.cpp
+++ b/evrApp/src/evr.cpp
@@ -192,6 +192,8 @@ OBJECT_BEGIN(PreScaler) {
 
     OBJECT_PROP2("Divide", &PreScaler::prescaler, &PreScaler::setPrescaler);
 
+    OBJECT_PROP2("Phase Offset", &PreScaler::prescalerPhasOffs, &PreScaler::setPrescalerPhasOffs);
+
 } OBJECT_END(PreScaler)
 
 

--- a/evrApp/src/evr/prescaler.h
+++ b/evrApp/src/evr/prescaler.h
@@ -26,6 +26,9 @@ public:
   virtual epicsUInt32 prescaler() const=0;
   virtual void setPrescaler(epicsUInt32)=0;
 
+  virtual epicsUInt32 prescalerPhasOffs() const { return 0; };
+  virtual void setPrescalerPhasOffs(epicsUInt32) { };
+
   EVR& owner;
 };
 

--- a/evrMrmApp/src/drvemPrescaler.cpp
+++ b/evrMrmApp/src/drvemPrescaler.cpp
@@ -31,3 +31,15 @@ MRMPreScaler::setPrescaler(epicsUInt32 v)
 {
     nat_iowrite32(base, v);
 }
+
+epicsUInt32
+MRMPreScaler::prescalerPhasOffs() const
+{
+    return nat_ioread32(base + ScalerPhasOffs_offset);
+}
+
+void
+MRMPreScaler::setPrescalerPhasOffs(epicsUInt32 v)
+{
+    nat_iowrite32(base + ScalerPhasOffs_offset, v);
+}

--- a/evrMrmApp/src/drvemPrescaler.h
+++ b/evrMrmApp/src/drvemPrescaler.h
@@ -28,6 +28,9 @@ public:
 
     virtual epicsUInt32 prescaler() const;
     virtual void setPrescaler(epicsUInt32);
+
+    virtual epicsUInt32 prescalerPhasOffs() const;
+    virtual void setPrescalerPhasOffs(epicsUInt32);
 };
 
 #endif // MRMEVRPRESCALER_H_INC

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -190,6 +190,7 @@
 #  define ScalerMax 3
 /* 0 <= N <= 2 */
 #define U32_Scaler(N)   (U32_ScalerN + (4*(N)))
+#  define ScalerPhasOffs_offset 0x20
 
 #define U32_PulserNCtrl 0x200
 #define U32_PulserNScal 0x204


### PR DESCRIPTION
introduced in firmware 0D0207 (20. May 2019) affected HW: mTCA-EVR-300
see p.72 of June 19. 2019 MRF Technical Reference for reg addresses.
This commit adds records that can control phase offset of prescalers in
degrees "PhasOffs-SP" or directly in Event Clock ticks "PhasOffs:Raw-SP"

I have tested both pairs of SP/RB.