### PR TITLE
Add buffered capture of event timestamps

### DIFF
--- a/documentation/evr-usage.lyx
+++ b/documentation/evr-usage.lyx
@@ -4839,7 +4839,7 @@ The shared memory interface can only be used to provide time with microsecond
 \end_layout
 
 \begin_layout Standard
-If the propogation time from the time source to the EVR is known, then the
+If the propagation time from the time source to the EVR is known, then the
  offset can be given by adding 
 \begin_inset Quotes eld
 \end_inset
@@ -4853,6 +4853,112 @@ time1 0.XXX
 ntp.conf
 \shape default
 .
+\end_layout
+
+\begin_layout Section
+Buffered Timestamp Capture
+\end_layout
+
+\begin_layout Standard
+Some applications are interested in the precise reception timestamp of an
+ asynchronous event code.
+ For example, an External event code from an EVR Input.
+ Further, if this Input/event code occurs at a high rate, it is preferable
+ for software to process reception times in batches.
+\end_layout
+
+\begin_layout Standard
+The motivating use case for this feature was monitoring of a rotational
+ encoder which produces a pulse on crossing a particular angle.
+ The times of this crossing are needed to calculate frequency and phase.
+ Further, crossing occur at ~1KHz.
+\end_layout
+
+\begin_layout Standard
+Buffers are setup by loading instances of the 
+\begin_inset listings
+inline true
+status open
+
+\begin_layout Plain Layout
+
+db/mrmevrtsbuf.db
+\end_layout
+
+\end_inset
+
+ database.
+ Many buffers may be loaded.
+ While un-useful it is possible to associate multiple buffers with the same
+ event code.
+\end_layout
+
+\begin_layout Standard
+\begin_inset listings
+inline false
+status open
+
+\begin_layout Plain Layout
+
+dbLoadRecords("db/evr-pcie-300dc.db","SYS=TST, D=evr:1, EVR=EVR,
+\backslash
+
+\end_layout
+
+\begin_layout Plain Layout
+
+               FEVT=125")
+\end_layout
+
+\begin_layout Plain Layout
+
+dbLoadRecords("db/mrmevrtsbuf.db", "SYS=TST, D=evr:1-ts:1, EVR=EVR,
+\backslash
+
+\end_layout
+
+\begin_layout Plain Layout
+
+               CODE=20, TRIG=10, FLUSH=TimesRelFlush")
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+In this example, the (optional) CODE and TRIG macros name two event codes.
+ CODE=20 is the event for which the reception time will be captured.
+ The (also optional) TRIG=10 is an event for which reception will cause
+ the internal buffer of timestamps to be flushed to a waveform record.
+ Alternately, flushing can be triggered by another record.
+\end_layout
+
+\begin_layout Standard
+The CODE and TRIG macros are setting the default values of fields which
+ may be changed at runtime.
+\end_layout
+
+\begin_layout Standard
+Each waveform record which present timestamps does so in a format determined
+ by the FLUSH macro.
+\end_layout
+
+\begin_layout Description
+TimesRelFlush Elements are times in nanoseconds relative to the flushing
+ action (either flush event code, or manual flush).
+ The time of the flushing action is stored as the record timestamp.
+ Element values are always negative.
+ This is the default if FLUSH is not set.
+\end_layout
+
+\begin_layout Description
+TimesRelFirst Elements are times in nanoseconds relative to the time of
+ the first event received after a previous flush.
+ The time of the first event is stored in the record timestamp.
+ Element values are always positive, and the first element value is always
+ zero.
 \end_layout
 
 \begin_layout Section

--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -9,6 +9,7 @@ DB += mrmevrout.db
 DB += mrmevrbase.template
 DB += mrmevrdc.template
 DB += mrmevrbufrx.db
+DB += mrmevrtsbuf.db
 DB += sequencedemo.db
 
 DB += evr-pmc-230.db

--- a/evrMrmApp/Db/mrmevrtsbuf.db
+++ b/evrMrmApp/Db/mrmevrtsbuf.db
@@ -6,9 +6,24 @@
 # CODE - Capture times of this event
 # TRIG - Flush buffer when this event is received.  may be 0
 
+# Buffered reception times.
+#
+# The meaning of elements of the waveform depends on the FLUSH macro.
+# Allowed values are:
+#
+# TimesRelFlush
+#   Elements are times in nanoseconds relative to the flushing action (either flush event code, or manual flush).
+#   The time of the flushing action is stored as the record timestamp.  Element values are always
+#   negative.
+#
+# TimesRelFirst
+#   Elements are times in nanoseconds relative to the time of the first event received after a previous flush.
+#   The time of the first event is stored in the record timestamp.  Element values are always positive,
+#   and the first element value is always zero.
+#
 record(waveform, "$(SYS){$(D)}TS-I") {
     field(DTYP, "Obj Prop waveform in")
-    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimesRelFlush")
+    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=$(FLUSH=TimesRelFlush)")
     field(SCAN, "I/O Intr")
     field(FTVL, "LONG") # int32
     field(NELM, "$(NELM=128)")

--- a/evrMrmApp/Db/mrmevrtsbuf.db
+++ b/evrMrmApp/Db/mrmevrtsbuf.db
@@ -20,6 +20,12 @@ record(longout, "$(SYS){$(D)}CptEvt-SP") {
     field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimeEvent")
     field(VAL , "$(CODE=0)")
     field(PINI, "YES")
+    field(FLNK, "$(SYS){$(D)}CptEvt-RB")
+}
+
+record(longin, "$(SYS){$(D)}CptEvt-RB") {
+    field(DTYP, "Obj Prop uint16")
+    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimeEvent")
 }
 
 record(longout, "$(SYS){$(D)}FlshEvt-SP") {
@@ -27,6 +33,12 @@ record(longout, "$(SYS){$(D)}FlshEvt-SP") {
     field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushEvent")
     field(VAL , "$(TRIG=0)")
     field(PINI, "YES")
+    field(FLNK, "$(SYS){$(D)}FlshEvt-RB")
+}
+
+record(longin, "$(SYS){$(D)}FlshEvt-RB") {
+    field(DTYP, "Obj Prop uint16")
+    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushEvent")
 }
 
 record(bo, "$(SYS){$(D)}Flsh-SP") {

--- a/evrMrmApp/Db/mrmevrtsbuf.db
+++ b/evrMrmApp/Db/mrmevrtsbuf.db
@@ -1,0 +1,50 @@
+# Capture event timestamps in Buffer.
+#
+# SYS, D - Record name componenets
+# EVR - EVR object name
+# NAME - Capture buffer instance name.  Default (EVR):CPT(CODE)
+# CODE - Capture times of this event
+# TRIG - Flush buffer when this event is received.  may be 0
+
+record(waveform, "$(SYS){$(D)}TS-I") {
+    field(DTYP, "Obj Prop waveform in")
+    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimesRelFlush")
+    field(SCAN, "I/O Intr")
+    field(FTVL, "LONG") # int32
+    field(NELM, "$(NELM=128)")
+    field(TSE , "-2")
+}
+
+record(longout, "$(SYS){$(D)}CptEvt-SP") {
+    field(DTYP, "Obj Prop uint16")
+    field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimeEvent")
+    field(VAL , "$(CODE=0)")
+    field(PINI, "YES")
+}
+
+record(longout, "$(SYS){$(D)}FlshEvt-SP") {
+    field(DTYP, "Obj Prop uint16")
+    field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushEvent")
+    field(VAL , "$(TRIG=0)")
+    field(PINI, "YES")
+}
+
+record(bo, "$(SYS){$(D)}Flsh-SP") {
+    field(DTYP, "Obj Prop command")
+    field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushManual")
+    field(VAL , "$(TRIG=0)")
+    field(ZNAM, "Flush")
+    field(ONAM, "Flush")
+}
+
+record(longin, "$(SYS){$(D)}Drop-I") {
+    field(DTYP, "Obj Prop uint32")
+    field(SCAN, "10 second")
+    field(INP , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=DropCnt")
+    field(FLNK, "$(SYS){$(D)}DropRate-I")
+}
+
+record(calc, "$(SYS){$(D)}DropRate-I") {
+    field(INPA, "$(SYS){$(D)}Drop-I NPP")
+    field(CALC, "C:=A-B;B:=A;C/10")
+}

--- a/evrMrmApp/src/Makefile
+++ b/evrMrmApp/src/Makefile
@@ -26,6 +26,7 @@ evrMrm_SRCS += drvemInput.cpp
 evrMrm_SRCS += drvemPrescaler.cpp
 evrMrm_SRCS += drvemPulser.cpp
 evrMrm_SRCS += drvemCML.cpp
+evrMrm_SRCS += drvemTSBuffer.cpp
 evrMrm_SRCS += delayModule.cpp
 evrMrm_SRCS += drvemRxBuf.cpp
 evrMrm_SRCS += devMrmBuf.cpp

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1328,6 +1328,7 @@ EVRMRM::drain_fifo()
                         buf.pos++;
 
                     } else {
+                        buf.drop = true;
                         tbuf->dropped++;
                     }
                 }

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -33,6 +33,7 @@
 #include "drvemPrescaler.h"
 #include "drvemPulser.h"
 #include "drvemCML.h"
+#include "drvemTSBuffer.h"
 #include "delayModule.h"
 #include "drvemRxBuf.h"
 #include "mrmevrseq.h"
@@ -46,7 +47,7 @@
 
 class EVRMRM;
 
-struct epicsShareClass eventCode {
+struct eventCode {
     epicsUInt8 code; // constant
     EVRMRM* owner;
 
@@ -58,6 +59,9 @@ struct epicsShareClass eventCode {
     epicsUInt32 last_sec;
     epicsUInt32 last_evt;
 
+    typedef std::set<EVRMRMTSBuffer*> tbufs_t;
+    tbufs_t tbufs;
+
     IOSCANPVT occured;
 
     typedef std::list<std::pair<EVR::eventCallback,void*> > notifiees_t;
@@ -68,7 +72,7 @@ struct epicsShareClass eventCode {
     bool again;
 
     eventCode():owner(0), interested(0), last_sec(0)
-            ,last_evt(0), notifiees(), waitingfor(0), again(false)
+            ,last_evt(0), waitingfor(0), again(false)
     {
         scanIoInit(&occured);
         // done - initialized in EVRMRM::EVRMRM()
@@ -314,6 +318,8 @@ private:
     void _map(epicsUInt8 evt, epicsUInt8 func)   { _mapped[evt] |=    1<<(func);  }
     void _unmap(epicsUInt8 evt, epicsUInt8 func) { _mapped[evt] &= ~( 1<<(func) );}
     bool _ismap(epicsUInt8 evt, epicsUInt8 func) const { return (_mapped[evt] & 1<<(func)) != 0; }
+
+    friend struct EVRMRMTSBuffer;
 }; // class EVRMRM
 
 #endif // EVRMRML_H_INC

--- a/evrMrmApp/src/drvemTSBuffer.cpp
+++ b/evrMrmApp/src/drvemTSBuffer.cpp
@@ -77,6 +77,7 @@ void EVRMRMTSBuffer::flushNow()
         ebufs[active].flushtime.secPastEpoch = 0u;
         ebufs[active].flushtime.nsec = 0u;
         ebufs[active].ok = false;
+        ebufs[active].drop = false;
     }
 
     doFlush();
@@ -89,6 +90,7 @@ void EVRMRMTSBuffer::doFlush()
     ebufs[active].pos = 0u;
     // a valid buffer requires timestamp validity at start and end flush
     ebufs[active].ok = evr->TimeStampValid();
+    ebufs[active].drop = false;
 
     scanIoRequest(scan);
 }
@@ -106,6 +108,8 @@ epicsUInt32 getTimes(const EVRMRMTSBuffer* self, epicsInt32 *arr, epicsUInt32 co
 
     if(prec && !readout.ok) {
         recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+    } else if(prec && readout.drop) {
+        recGblSetSevr(prec, READ_ALARM, MAJOR_ALARM);
     } else if(prec && readout.ok) {
         prec->time = readout.flushtime;
     }

--- a/evrMrmApp/src/drvemTSBuffer.cpp
+++ b/evrMrmApp/src/drvemTSBuffer.cpp
@@ -43,8 +43,10 @@ void EVRMRMTSBuffer::flushTimeSet(epicsUInt16 v)
 
     if(timeEvt) {
         evr->events[timeEvt].tbufs.erase(this);
+        evr->interestedInEvent(timeEvt, false);
     }
     if(v) {
+        evr->interestedInEvent(v, true);
         evr->events[v].tbufs.insert(this);
     }
     timeEvt = v;
@@ -59,8 +61,10 @@ void EVRMRMTSBuffer::flushEventSet(epicsUInt16 v)
 
     if(flushEvt) {
         evr->events[flushEvt].tbufs.erase(this);
+        evr->interestedInEvent(flushEvt, false);
     }
     if(v) {
+        evr->interestedInEvent(v, true);
         evr->events[v].tbufs.insert(this);
     }
     flushEvt = v;

--- a/evrMrmApp/src/drvemTSBuffer.cpp
+++ b/evrMrmApp/src/drvemTSBuffer.cpp
@@ -1,0 +1,192 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* mrfioc2 is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "drvem.h"
+#include "drvemTSBuffer.h"
+#include "devObj.h"
+
+EVRMRMTSBuffer::EVRMRMTSBuffer(const std::string &n, EVRMRM *evr)
+    :base_t(n)
+    ,evr(evr)
+    ,dropped(0u)
+    ,timeEvt(0u)
+    ,flushEvt(0u)
+    ,active(0u)
+{
+    scanIoInit(&scan);
+}
+
+EVRMRMTSBuffer::~EVRMRMTSBuffer()
+{
+
+}
+
+void EVRMRMTSBuffer::lock() const
+{
+    evr->lock();
+}
+
+void EVRMRMTSBuffer::unlock() const
+{
+    evr->unlock();
+}
+
+void EVRMRMTSBuffer::flushTimeSet(epicsUInt16 v)
+{
+    if(v==timeEvt)
+        return;
+    if(v==flushEvent() || v>0xff)
+        throw std::invalid_argument("Can't capture with flush code or >255");
+
+    if(timeEvt) {
+        evr->events[timeEvt].tbufs.erase(this);
+    }
+    if(v) {
+        evr->events[v].tbufs.insert(this);
+    }
+    timeEvt = v;
+}
+
+void EVRMRMTSBuffer::flushEventSet(epicsUInt16 v)
+{
+    if(v==flushEvt)
+        return;
+    if(v==timeEvt || v>0xff)
+        throw std::invalid_argument("Can't flush with capture code or >255");
+
+    if(flushEvt) {
+        evr->events[flushEvt].tbufs.erase(this);
+    }
+    if(v) {
+        evr->events[v].tbufs.insert(this);
+    }
+    flushEvt = v;
+}
+
+// caller must hold evrLock
+void EVRMRMTSBuffer::flushNow()
+{
+    if(epicsTimeGetCurrent(&ebufs[active].flushtime)) {
+        ebufs[active].flushtime.secPastEpoch = 0u;
+        ebufs[active].flushtime.nsec = 0u;
+        ebufs[active].ok = false;
+    }
+
+    doFlush();
+}
+
+void EVRMRMTSBuffer::doFlush()
+{
+    active ^= 1u;
+
+    ebufs[active].pos = 0u;
+    // a valid buffer requires timestamp validity at start and end flush
+    ebufs[active].ok = evr->TimeStampValid();
+
+    scanIoRequest(scan);
+}
+
+enum TimesRef {
+    TimesRefEvt0,
+    TimesRefFlush,
+};
+
+static
+epicsUInt32 getTimes(const EVRMRMTSBuffer* self, epicsInt32 *arr, epicsUInt32 count, TimesRef ref)
+{
+    const EVRMRMTSBuffer::ebuf_t& readout = self->ebufs[self->active^1u];
+    dbCommon* prec = CurrentRecord::get();
+
+    if(prec && !readout.ok) {
+        recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+    } else if(prec && readout.ok) {
+        prec->time = readout.flushtime;
+    }
+
+    double period=1e9/self->evr->clockTS(); // in nanoseconds
+
+    size_t len = std::min(readout.pos, size_t(count));
+
+    if(readout.buf.size() < count) {
+        const_cast<EVRMRMTSBuffer::ebuf_t&>(readout).buf.resize(count);
+    }
+
+    if(period<=0 || !isfinite(period)) {
+        if(count>0u) {
+            arr[0] = 0;
+            count = 1u;
+        }
+        recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
+        return count;
+    }
+
+    epicsTimeStamp tref;
+    if(ref==TimesRefFlush)
+        tref = readout.flushtime;
+
+    for(size_t i=0; i<len; i++) {
+        epicsTimeStamp ts = readout.buf[i];
+
+        // readout.ok captures validity of timestamp at start and end of interval.
+        // skip validation of timestamps in between.
+        ts.secPastEpoch -= POSIX_TIME_AT_EPICS_EPOCH;
+        ts.nsec = epicsUInt32(ts.nsec*period);
+
+        if(i==0 && ref==TimesRefEvt0) {
+            tref = ts;
+        }
+
+        double diff = epicsTimeDiffInSeconds(&ts, &tref);
+        arr[i] = epicsInt32(diff*1e9); // ns
+    }
+
+    return len;
+}
+
+epicsUInt32 EVRMRMTSBuffer::getTimesRelFirst(epicsInt32 *arr, epicsUInt32 count) const
+{
+    return getTimes(this, arr, count, TimesRefEvt0);
+}
+
+epicsUInt32 EVRMRMTSBuffer::getTimesRelFlush(epicsInt32 *arr, epicsUInt32 count) const
+{
+    return getTimes(this, arr, count, TimesRefFlush);
+}
+
+static
+mrf::Object*
+buildInstance(const std::string& name, const std::string& klass, const mrf::Object::create_args_t& args)
+{
+    (void)klass;
+    mrf::Object::create_args_t::const_iterator it;
+
+    if((it=args.find("PARENT"))==args.end())
+        throw std::runtime_error("No PARENT= (EVR) specified");
+
+    mrf::Object *evrobj = mrf::Object::getObject(it->second);
+    if(!evrobj)
+        throw std::runtime_error("No such PARENT object");
+
+    EVRMRM *evr = dynamic_cast<EVRMRM*>(evrobj);
+    if(!evr)
+        throw std::runtime_error("PARENT is not a MRMEVR");
+
+    mrf::auto_ptr<EVRMRMTSBuffer> ret(new EVRMRMTSBuffer(name, evr));
+
+    return ret.release();
+}
+
+OBJECT_BEGIN(EVRMRMTSBuffer)
+    OBJECT_FACTORY(&buildInstance);
+    OBJECT_PROP1("DropCnt", &EVRMRMTSBuffer::dropCount);
+    OBJECT_PROP2("TimeEvent", &EVRMRMTSBuffer::timeEvent, &EVRMRMTSBuffer::flushTimeSet);
+    OBJECT_PROP2("FlushEvent", &EVRMRMTSBuffer::flushEvent, &EVRMRMTSBuffer::flushEventSet);
+    OBJECT_PROP1("FlushManual", &EVRMRMTSBuffer::flushNow);
+    OBJECT_PROP1("TimesRelFirst", &EVRMRMTSBuffer::getTimesRelFirst);
+    OBJECT_PROP1("TimesRelFirst", &EVRMRMTSBuffer::flushed);
+    OBJECT_PROP1("TimesRelFlush", &EVRMRMTSBuffer::getTimesRelFlush);
+    OBJECT_PROP1("TimesRelFlush", &EVRMRMTSBuffer::flushed);
+OBJECT_END(EVRMRMTSBuffer)

--- a/evrMrmApp/src/drvemTSBuffer.h
+++ b/evrMrmApp/src/drvemTSBuffer.h
@@ -55,7 +55,8 @@ struct EVRMRMTSBuffer : public mrf::ObjectInst<EVRMRMTSBuffer>
         std::vector<epicsTimeStamp> buf;
         epicsTimeStamp flushtime;
         bool ok;
-        ebuf_t() :pos(0u), ok(false) {
+        bool drop;
+        ebuf_t() :pos(0u), ok(false), drop(false) {
             flushtime.secPastEpoch = 0u;
             flushtime.nsec = 0u;
         }

--- a/evrMrmApp/src/drvemTSBuffer.h
+++ b/evrMrmApp/src/drvemTSBuffer.h
@@ -38,6 +38,7 @@ struct EVRMRMTSBuffer : public mrf::ObjectInst<EVRMRMTSBuffer>
 
     epicsUInt32 getTimesRelFirst(epicsInt32 *arr, epicsUInt32 count) const;
     epicsUInt32 getTimesRelFlush(epicsInt32 *arr, epicsUInt32 count) const;
+    epicsUInt32 getTimesRelPrevFlush(epicsInt32 *arr, epicsUInt32 count) const;
 
     IOSCANPVT flushed() const { return scan; }
 
@@ -53,12 +54,13 @@ struct EVRMRMTSBuffer : public mrf::ObjectInst<EVRMRMTSBuffer>
     struct ebuf_t {
         size_t pos;
         std::vector<epicsTimeStamp> buf;
-        epicsTimeStamp flushtime;
-        bool ok;
+        epicsTimeStamp flushtime, prevflushtime;
+        bool ok, prevok;
         bool drop;
-        ebuf_t() :pos(0u), ok(false), drop(false) {
+        ebuf_t() :pos(0u), ok(false), prevok(false), drop(false) {
             flushtime.secPastEpoch = 0u;
             flushtime.nsec = 0u;
+            prevflushtime = flushtime;
         }
     private:
         ebuf_t(const ebuf_t&);

--- a/evrMrmApp/src/drvemTSBuffer.h
+++ b/evrMrmApp/src/drvemTSBuffer.h
@@ -1,0 +1,70 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* mrfioc2 is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+#ifndef DRVEMTSBUFFER_H
+#define DRVEMTSBUFFER_H
+
+#include <vector>
+#include <utility> // std::pair
+
+#include <dbScan.h>
+
+#include "mrf/object.h"
+
+class EVRMRM;
+
+struct EVRMRMTSBuffer : public mrf::ObjectInst<EVRMRMTSBuffer>
+{
+    typedef mrf::ObjectInst<EVRMRMTSBuffer> base_t;
+
+    explicit EVRMRMTSBuffer(const std::string& n, EVRMRM* evr);
+    virtual ~EVRMRMTSBuffer();
+
+    virtual void lock() const OVERRIDE FINAL;
+    virtual void unlock() const OVERRIDE FINAL;
+
+    epicsUInt32 dropCount() const { return dropped; }
+
+    epicsUInt16 timeEvent() const { return timeEvt; }
+    void flushTimeSet(epicsUInt16 v);
+
+    epicsUInt16 flushEvent() const { return flushEvt; }
+    void flushEventSet(epicsUInt16 v);
+
+    void flushNow();
+    void doFlush();
+
+    epicsUInt32 getTimesRelFirst(epicsInt32 *arr, epicsUInt32 count) const;
+    epicsUInt32 getTimesRelFlush(epicsInt32 *arr, epicsUInt32 count) const;
+
+    IOSCANPVT flushed() const { return scan; }
+
+    EVRMRM* const evr;
+
+    epicsUInt32 dropped;
+
+    IOSCANPVT scan;
+
+    epicsUInt8 timeEvt;
+    epicsUInt8 flushEvt;
+
+    struct ebuf_t {
+        size_t pos;
+        std::vector<epicsTimeStamp> buf;
+        epicsTimeStamp flushtime;
+        bool ok;
+        ebuf_t() :pos(0u), ok(false) {
+            flushtime.secPastEpoch = 0u;
+            flushtime.nsec = 0u;
+        }
+    private:
+        ebuf_t(const ebuf_t&);
+    } ebufs[2];
+    // active buffer being filled.  Other is for readout.
+    // must lock both evr and this mutex to change.
+    unsigned char active; // either 0 or 1
+};
+
+#endif // DRVEMTSBUFFER_H


### PR DESCRIPTION
Adds the ability to configure per-event buffering of event RX timestamps, with readout as a batch (in a `waveformRecord`).  Batches are marked either by a manually via a record, or by a reception of second "flush" event code.  Times are double buffered, so results will remain stable during readout.  Buffer depth is determined by the largest `NELM` among the waveformRecords associated with a buffer.  There is a per-buffer overflow counter.

Events times may be encoded into a waveformRecord in three ways: TimesRelFirst, TimesRelFlush, or TimesRelPrevFlush.