### PR TITLE
RFC: Add EVR Prescaler Pulse-Generator Trigger functionality

### DIFF
--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -92,3 +92,22 @@ record(calc, "$(SN)PhasOffs-RB") {
   field( INPA, "$(SN)Div-RB")
   field( INPB, "$(SN)PhasOffs:Raw-RB PP")
 }
+
+record(mbboDirect, "$(SN)PulsTrig-Sel") {
+  field(DTYP, "Obj Prop uint32")
+  field(DESC, "Prescaler Pulse Generator Trigger")
+  field(OMSL, "supervisory")
+  field(OUT , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+  field(PINI, "YES")
+  field(NOBT, "32")
+  field(VAL , "0")
+  field(FLNK, "$(SN)PulsTrig-RB")
+  info(autosaveFields_pass0, "RVAL")
+}
+
+record(mbbiDirect, "$(SN)PulsTrig-RB") {
+  field(DTYP, "Obj Prop uint32")
+  field(DESC, "Prescaler Pulse Generator Trigger")
+  field(INP , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+  field(NOBT, "32")
+}

--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -93,21 +93,23 @@ record(calc, "$(SN)PhasOffs-RB") {
   field( INPB, "$(SN)PhasOffs:Raw-RB PP")
 }
 
-record(mbboDirect, "$(SN)PulsTrig-Sel") {
-  field(DTYP, "Obj Prop uint32")
-  field(DESC, "Prescaler Pulse Generator Trigger")
-  field(OMSL, "supervisory")
-  field(OUT , "@OBJ=$(OBJ), PROP=Pulser Trigger")
-  field(PINI, "YES")
-  field(NOBT, "32")
-  field(VAL , "0")
-  field(FLNK, "$(SN)PulsTrig-RB")
+record(longout, "$(SN)PulsTrig-SP") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Pulse Generator Trigger")
+  field( OMSL, "supervisory")
+  field( OUT , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "0xffff")
+  field( LOPR, "0")
+  field( DRVH, "0xffff")
+  field( DRVL, "0")
+  field( FLNK, "$(SN)PulsTrig-RB")
   info(autosaveFields_pass0, "RVAL")
 }
 
-record(mbbiDirect, "$(SN)PulsTrig-RB") {
-  field(DTYP, "Obj Prop uint32")
-  field(DESC, "Prescaler Pulse Generator Trigger")
-  field(INP , "@OBJ=$(OBJ), PROP=Pulser Trigger")
-  field(NOBT, "32")
+record(longin, "$(SN)PulsTrig-RB") {
+  field( DTYP, "Obj Prop uint32")
+  field( DESC, "Prescaler $(IDX) Pulse Generator Trigger")
+  field( INP , "@OBJ=$(OBJ), PROP=Pulser Trigger")
 }

--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -93,23 +93,21 @@ record(calc, "$(SN)PhasOffs-RB") {
   field( INPB, "$(SN)PhasOffs:Raw-RB PP")
 }
 
-record(longout, "$(SN)PulsTrig-SP") {
-  field( DTYP, "Obj Prop uint32")
-  field( DESC, "Prescaler $(IDX) Pulse Generator Trigger")
-  field( OMSL, "supervisory")
-  field( OUT , "@OBJ=$(OBJ), PROP=Pulser Trigger")
-  field( PINI, "YES")
-  field( VAL , "0")
-  field( HOPR, "0xffff")
-  field( LOPR, "0")
-  field( DRVH, "0xffff")
-  field( DRVL, "0")
-  field( FLNK, "$(SN)PulsTrig-RB")
+record(mbboDirect, "$(SN)PulsTrig-Sel") {
+  field(DTYP, "Obj Prop uint32")
+  field(DESC, "Prescaler Pulse Generator Trigger")
+  field(OMSL, "supervisory")
+  field(OUT , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+  field(PINI, "YES")
+  field(NOBT, "32")
+  field(VAL , "0")
+  field(FLNK, "$(SN)PulsTrig-RB")
   info(autosaveFields_pass0, "RVAL")
 }
 
-record(longin, "$(SN)PulsTrig-RB") {
-  field( DTYP, "Obj Prop uint32")
-  field( DESC, "Prescaler $(IDX) Pulse Generator Trigger")
-  field( INP , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+record(mbbiDirect, "$(SN)PulsTrig-RB") {
+  field(DTYP, "Obj Prop uint32")
+  field(DESC, "Prescaler Pulse Generator Trigger")
+  field(INP , "@OBJ=$(OBJ), PROP=Pulser Trigger")
+  field(NOBT, "32")
 }

--- a/evrMrmApp/src/drvemPrescaler.cpp
+++ b/evrMrmApp/src/drvemPrescaler.cpp
@@ -51,6 +51,19 @@ MRMPreScaler::setPrescalerPhasOffs(epicsUInt32 v)
     nat_iowrite32(base + ScalerPhasOffs_offset, v);
 }
 
+epicsUInt32
+MRMPreScaler::prescalerPulsTrig() const
+{
+    return nat_ioread32(base + ScalerPulsTrig_offset);
+}
+
+void
+MRMPreScaler::setPrescalerPulsTrig(epicsUInt32 v)
+{
+    nat_iowrite32(base + ScalerPulsTrig_offset, v);
+}
+
 OBJECT_BEGIN2(MRMPreScaler, PreScaler)
     OBJECT_PROP2("Phase Offset", &MRMPreScaler::prescalerPhasOffs, &MRMPreScaler::setPrescalerPhasOffs);
+    OBJECT_PROP2("Pulser Trigger", &MRMPreScaler::prescalerPulsTrig, &MRMPreScaler::setPrescalerPulsTrig);
 OBJECT_END(MRMPreScaler)

--- a/evrMrmApp/src/drvemPrescaler.h
+++ b/evrMrmApp/src/drvemPrescaler.h
@@ -31,6 +31,9 @@ public:
 
     epicsUInt32 prescalerPhasOffs() const;
     void setPrescalerPhasOffs(epicsUInt32);
+
+    epicsUInt32 prescalerPulsTrig() const;
+    void setPrescalerPulsTrig(epicsUInt32);
 };
 
 #endif // MRMEVRPRESCALER_H_INC

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -191,6 +191,7 @@
 /* 0 <= N <= 2 */
 #define U32_Scaler(N)   (U32_ScalerN + (4*(N)))
 #  define ScalerPhasOffs_offset 0x20
+#  define ScalerPulsTrig_offset 0x40
 
 #define U32_PulserNCtrl 0x200
 #define U32_PulserNScal 0x204


### PR DESCRIPTION
"Starting from firmware version 0200 pulse generators can also
be triggered from rising edges of ... EVR internal prescalers"
- MRF DC Technical Reference, p. 64 -  May 14 2020

This commit adds PulsTrig-(Sel/RB) mbb(i/o)Direct records,
which provide each EVR Prescaler with the ability to trigger
any combination of EVR Pulse Generators.

E.g. setting
   {EVR-PS:0}PulsTrig-Sel.B3 = 1
   {EVR-PS:0}PulsTrig-Sel.B8 = 1
   {EVR-PS:2}PulsTrig-Sel.B0 = 1
   {EVR-PS:2}PulsTrig-Sel.B3 = 1
will cause each rising edge of Prescaler 0 to trigger Pulse
Generators 3 & 8, and each rising edge of Prescaler 2 to
trigger Pulse Generators 0 & 3.