### PR TITLE
add prescaler polarity functions

### DIFF
--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -7,6 +7,18 @@
 #  IDX = ID # corresponding to output mapping codes
 #  MAX = Maximum division
 
+record(bo, "$(P)PSPolarity-Sel")
+{
+  field( DTYP, "Obj Prop bool")
+  field( DESC, "Polarity of prescalers")
+  field( OUT , "@OBJ=$(EVR), PROP=PSPolarity")
+  field( PINI, "YES")
+  field( ZNAM, "PS-sync on falling edge")
+  field( ONAM, "PS-sync on rising edge")
+  field( VAL , "0")
+  info(autosaveFields_pass0, "VAL")
+}
+
 record(longout, "$(SN)Div-SP") {
   field( DTYP, "Obj Prop uint32")
   field( DESC, "Prescaler $(IDX)")

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1000,6 +1000,20 @@ EVRMRM::dcStatusRaw() const
     return READ32(base, DCStatus);
 }
 
+bool
+EVRMRM::psPolarity() const {
+	return READ32(base, Control) & Control_pspol;
+}
+
+void
+EVRMRM::psPolaritySet(bool v)
+{
+    if(v)
+        BITSET32(base, Control, Control_pspol);
+    else
+        BITCLR32(base, Control, Control_pspol);
+}
+
 epicsUInt32
 EVRMRM::topId() const
 {
@@ -1069,6 +1083,7 @@ OBJECT_BEGIN2(EVRMRM, EVR)
   OBJECT_PROP1("DCInt",    &EVRMRM::dcInternal);
   OBJECT_PROP1("DCStatusRaw", &EVRMRM::dcStatusRaw);
   OBJECT_PROP1("DCTOPID", &EVRMRM::topId);
+  OBJECT_PROP2("PSPolarity", &EVRMRM::psPolarity, &EVRMRM::psPolaritySet);
   OBJECT_PROP2("EvtCode", &EVRMRM::dummy, &EVRMRM::setEvtCode);
   OBJECT_PROP2("TimeSrc", &EVRMRM::timeSrc, &EVRMRM::setTimeSrc);
     {

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -205,6 +205,9 @@ public:
     epicsUInt32 dcStatusRaw() const;
     epicsUInt32 topId() const;
 
+    bool psPolarity() const;
+    void psPolaritySet(bool v);
+
     epicsUInt32 dummy() const { return 0; }
     void setEvtCode(epicsUInt32 code) OVERRIDE FINAL;
 

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -69,6 +69,8 @@
 
 #  define Control_DCEna   0x00400000
 
+#  define Control_pspol   0x00008000 /* prescaler polarity */
+
 /*                        Timestamp clock on DBUS #4 */
 #  define Control_tsdbus  0x00004000
 #  define Control_tsrst   0x00002000


### PR DESCRIPTION
By default the prescalers are aligned by the falling edge. This can
be changed by toggling the prescaler polarity bit (bit 15 in Control
Register).

Where would be a good place to put the corresponding records?