### PR TITLE
fix EVR PhasOffs processing

### DIFF
--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -59,7 +59,7 @@ record(calcout, "$(SN)PhasOffs-CO_") {
   field( DESC, "Degrees to Event Clock Ticks")
   field( OUT , "$(SN)PhasOffs:Raw-SP PP")
   field( CALC, "FLOOR(B/360*A)")
-  field( INPA, "$(SN)Div-RB CPP")
+  field( INPA, "$(SN)Div-RB")
   field( INPB, "$(SN)PhasOffs-SP")
 }
 
@@ -89,6 +89,6 @@ record(calc, "$(SN)PhasOffs-RB") {
   field( DESC, "Prescaler $(IDX) Phase Offset")
   field( CALC, "B/A*360")
   field( EGU , "Deg")
-  field( INPA, "$(SN)Div-RB")
+  field( INPA, "$(SN)Div-RB CPP")
   field( INPB, "$(SN)PhasOffs:Raw-RB PP")
 }


### PR DESCRIPTION
at the moment, changing prescaler's Div-SP causes PhasOffs-CO_ to reset
prescaler's phase-offset to 0 if user used PhasOffs:Raw-SP to set it.

Fix this, by hanging Div-RB CPP on -RB not on -SP.