### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -103,6 +103,16 @@ jobs:
             configuration: default
             base: "7.0"
 
+          - os: windows-2019
+            cmp: vs2019
+            configuration: default
+            base: "7.0"
+
+          - os: windows-2019
+            cmp: vs2019
+            configuration: static
+            base: "7.0"
+
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ mrmShared_DEPEND_DIRS += mrfCommon
 
 evrMrmApp_DEPEND_DIRS += evrApp mrmShared
 
-evgMrmApp_DEPEND_DIRS += mrmShared
+evgMrmApp_DEPEND_DIRS += evrMrmApp
 
 evrFRIBApp_DEPEND_DIRS += evrApp
 

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -28,6 +28,9 @@
 # but want to suppress deprecation warnings
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 
+USR_CPPFLAGS_WIN32 += -DNOMINMAX
+USR_CPPFLAGS_WIN32 += -DWIN32_LEAN_AND_MEAN
+
 # Uncomment the following to enable strict treatment of warnings
 #USR_CFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror -Wno-error=deprecated-declarations
 #USR_CXXFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror -Wno-error=deprecated-declarations

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -31,6 +31,9 @@ USR_CPPFLAGS += -DUSE_TYPED_RSET
 USR_CPPFLAGS_WIN32 += -DNOMINMAX
 USR_CPPFLAGS_WIN32 += -DWIN32_LEAN_AND_MEAN
 
+# beginning with Base 3.15.7, can avoid windows #define CALLBACK conflict
+USR_CPPFLAGS += -DEPICS_NO_CALLBACK
+
 # Uncomment the following to enable strict treatment of warnings
 #USR_CFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror -Wno-error=deprecated-declarations
 #USR_CXXFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror -Wno-error=deprecated-declarations

--- a/documentation/evr-usage.lyx
+++ b/documentation/evr-usage.lyx
@@ -3702,7 +3702,19 @@ Firmware Update
 \end_layout
 
 \begin_layout Subsection
-PCIe-EVR-300DC, mTCA-EVR-300
+300-series Devices
+\end_layout
+
+\begin_layout Itemize
+PCIe-EVR-300DC
+\end_layout
+
+\begin_layout Itemize
+mTCA-EVR-300
+\end_layout
+
+\begin_layout Itemize
+mTCA-EVM-300
 \end_layout
 
 \begin_layout Standard
@@ -3826,7 +3838,7 @@ flashinfo
 
 \begin_layout Standard
 In this example of a PCIe-EVR-300DC with the 207.0 firmware, the exact size
- is 3011417 bytes, which is arbitrarily rounded up to 3MB.
+ is 3011417 bytes, which we arbitrarily round up to 3MB.
 \end_layout
 
 \begin_layout Standard
@@ -3874,8 +3886,11 @@ epics> flashwrite("EVR1:FLASH", 0, "PCIe-EVR-300DC.207.6.bit")
 \end_layout
 
 \begin_layout Standard
-If the update process is interrupted, do not power cycle! Re-run the update
- process to completion.
+If the update process is interrupted, 
+\series bold
+do not power cycle
+\series default
+! Re-run the update process to completion.
 \end_layout
 
 \begin_layout Standard

--- a/evgMrmApp/src/Makefile
+++ b/evgMrmApp/src/Makefile
@@ -56,6 +56,8 @@ evgmrm_SRCS += seqnsls2.c
 
 evgmrm_LIBS += mrfCommon mrmShared epicsvme epicspci $(EPICS_BASE_IOC_LIBS)
 
+USR_SYS_LIBS_WIN32 += ws2_32
+
 DBD += evgInit.dbd
 
 #===========================

--- a/evgMrmApp/src/Makefile
+++ b/evgMrmApp/src/Makefile
@@ -54,7 +54,7 @@ evgmrm_SRCS += mrmevgseq.cpp
 evgmrm_SRCS += seqconst.c
 evgmrm_SRCS += seqnsls2.c
 
-evgmrm_LIBS += mrfCommon mrmShared epicsvme epicspci $(EPICS_BASE_IOC_LIBS)
+evgmrm_LIBS += mrfCommon evrMrm evr mrmShared epicsvme epicspci $(EPICS_BASE_IOC_LIBS)
 
 USR_SYS_LIBS_WIN32 += ws2_32
 

--- a/evgMrmApp/src/evgAcTrig.cpp
+++ b/evgMrmApp/src/evgAcTrig.cpp
@@ -15,9 +15,11 @@
 
 #include "evgRegMap.h"
 
-evgAcTrig::evgAcTrig(const std::string& name, volatile epicsUInt8* const pReg):
-mrf::ObjectInst<evgAcTrig>(name),
-m_pReg(pReg) {
+evgAcTrig::evgAcTrig(const std::string& name, volatile epicsUInt8* const pReg)
+    :mrf::ObjectInst<evgAcTrig>(name)
+    ,m_pReg(pReg)
+{
+    OBJECT_INIT;
 }
 
 evgAcTrig::~evgAcTrig() {

--- a/evgMrmApp/src/evgAcTrig.h
+++ b/evgMrmApp/src/evgAcTrig.h
@@ -5,6 +5,7 @@
 #include "mrf/object.h"
 
 class evgAcTrig : public mrf::ObjectInst<evgAcTrig> {
+    OBJECT_DECL(evgAcTrig);
 public:
     evgAcTrig(const std::string&, volatile epicsUInt8* const);
     ~evgAcTrig();

--- a/evgMrmApp/src/evgDbus.cpp
+++ b/evgMrmApp/src/evgDbus.cpp
@@ -9,10 +9,12 @@
 #include "evgRegMap.h"
 
 evgDbus::evgDbus(const std::string& name, const epicsUInt32 id,
-                 volatile epicsUInt8* const pReg):
-mrf::ObjectInst<evgDbus>(name),
-m_id(id),
-m_pReg(pReg) {
+                 volatile epicsUInt8* const pReg)
+    :mrf::ObjectInst<evgDbus>(name)
+    ,m_id(id)
+    ,m_pReg(pReg)
+{
+    OBJECT_INIT;
 }
 
 evgDbus::~evgDbus() {

--- a/evgMrmApp/src/evgDbus.h
+++ b/evgMrmApp/src/evgDbus.h
@@ -5,6 +5,7 @@
 #include "mrf/object.h"
 
 class evgDbus : public mrf::ObjectInst<evgDbus> {
+    OBJECT_DECL(evgDbus);
 public:
     evgDbus(const std::string&, const epicsUInt32,  volatile epicsUInt8* const);
     ~evgDbus();

--- a/evgMrmApp/src/evgInput.cpp
+++ b/evgMrmApp/src/evgInput.cpp
@@ -16,7 +16,9 @@ evgInput::evgInput(const std::string& name, const epicsUInt32 num,
     ,m_num(num)
     ,m_type(type)
     ,m_pInReg(pInReg)
-{}
+{
+    OBJECT_INIT;
+}
 
 evgInput::~evgInput() {
 }

--- a/evgMrmApp/src/evgInput.h
+++ b/evgMrmApp/src/evgInput.h
@@ -16,6 +16,7 @@ enum InputType {
 };
 
 class evgInput : public mrf::ObjectInst<evgInput> {
+    OBJECT_DECL(evgInput);
 public:
     evgInput(const std::string&, const epicsUInt32, const InputType,
              volatile epicsUInt8* const);

--- a/evgMrmApp/src/evgMrm.cpp
+++ b/evgMrmApp/src/evgMrm.cpp
@@ -92,6 +92,8 @@ evgMrm::evgMrm(const std::string& id,
     m_acTrig(id+":AcTrig", pReg),
   shadowIrqEnable(READ32(m_pReg, IrqEnable))
 {
+    OBJECT_INIT;
+
     epicsUInt32 v, isevr;
 
     v = READ32(m_pReg, FPGAVersion);

--- a/evgMrmApp/src/evgMrm.cpp
+++ b/evgMrmApp/src/evgMrm.cpp
@@ -205,7 +205,7 @@ void evgMrm::enableIRQ()
 }
 
 void 
-evgMrm::init_cb(CALLBACK *ptr, int priority, void(*fn)(CALLBACK*), void* valptr) { 
+evgMrm::init_cb(callbackPvt *ptr, int priority, void(*fn)(callbackPvt*), void* valptr) {
     callbackSetPriority(priority, ptr); 
     callbackSetCallback(fn, ptr);     
     callbackSetUser(valptr, ptr);     
@@ -373,7 +373,7 @@ try{
 }
 
 void
-evgMrm::process_inp_cb(CALLBACK *pCallback) {
+evgMrm::process_inp_cb(callbackPvt *pCallback) {
     void* pVoid;
     callbackGetUser(pVoid, pCallback);
     evgMrm* evg = static_cast<evgMrm*>(pVoid);

--- a/evgMrmApp/src/evgMrm.h
+++ b/evgMrmApp/src/evgMrm.h
@@ -130,8 +130,8 @@ public:
     static void isr_pci(void*);
     static void isr_vme(void*);
     static void isr_poll(void*);
-    static void init_cb(CALLBACK*, int, void(*)(CALLBACK*), void*);
-    static void process_inp_cb(CALLBACK*);
+    static void init_cb(callbackPvt*, int, void(*)(callbackPvt*), void*);
+    static void process_inp_cb(callbackPvt*);
 
     void setEvtCode(epicsUInt32);
 
@@ -143,7 +143,7 @@ public:
     epicsEvent* getTimerEvent();
     const bus_configuration* getBusConfiguration();
 
-    CALLBACK                      irqExtInp_cb;
+    callbackPvt                      irqExtInp_cb;
 
     unsigned char irqExtInp_queued;
 

--- a/evgMrmApp/src/evgMrm.h
+++ b/evgMrmApp/src/evgMrm.h
@@ -57,6 +57,7 @@ class evgMrm : public mrf::ObjectInst<evgMrm>,
                public TimeStampSource,
                public MRMSPI
 {
+    OBJECT_DECL(evgMrm);
 public:
     struct Config {
         const char *model;

--- a/evgMrmApp/src/evgMxc.cpp
+++ b/evgMrmApp/src/evgMxc.cpp
@@ -19,11 +19,13 @@
 #include "evgRegMap.h"
 
 evgMxc::evgMxc(const std::string& name, const epicsUInt32 id,
-               evgMrm* const owner):
-mrf::ObjectInst<evgMxc>(name),
-m_id(id),
-m_owner(owner),
-m_pReg(owner->getRegAddr()) {    
+               evgMrm* const owner)
+    :mrf::ObjectInst<evgMxc>(name)
+    ,m_id(id)
+    ,m_owner(owner)
+    ,m_pReg(owner->getRegAddr())
+{
+    OBJECT_INIT;
 }
 
 evgMxc::~evgMxc() {

--- a/evgMrmApp/src/evgMxc.h
+++ b/evgMrmApp/src/evgMxc.h
@@ -7,6 +7,7 @@
 class evgMrm;
 
 class evgMxc : public mrf::ObjectInst<evgMxc> {
+    OBJECT_DECL(evgMxc);
 public:
     evgMxc(const std::string&, const epicsUInt32, evgMrm* const);
     ~evgMxc();

--- a/evgMrmApp/src/evgOutput.cpp
+++ b/evgMrmApp/src/evgOutput.cpp
@@ -10,11 +10,14 @@
 #include "evgRegMap.h"
 
 evgOutput::evgOutput(const std::string& name, const epicsUInt32 num,
-                     const evgOutputType type, volatile epicsUInt8* const pOutReg):
-mrf::ObjectInst<evgOutput>(name),
-m_num(num),
-m_type(type),
-m_pOutReg(pOutReg) {
+                     const evgOutputType type, volatile epicsUInt8* const pOutReg)
+    :mrf::ObjectInst<evgOutput>(name)
+    ,m_num(num)
+    ,m_type(type)
+    ,m_pOutReg(pOutReg)
+{
+    OBJECT_INIT;
+
     switch(m_type) {        
         case(FrontOut):
             if(m_num >= evgNumFrontOut)

--- a/evgMrmApp/src/evgOutput.h
+++ b/evgMrmApp/src/evgOutput.h
@@ -11,6 +11,7 @@ enum evgOutputType {
 };
 
 class evgOutput : public mrf::ObjectInst<evgOutput> {
+    OBJECT_DECL(evgOutput);
 public:
     evgOutput(const std::string&, const epicsUInt32, const evgOutputType,
               volatile epicsUInt8* const);

--- a/evgMrmApp/src/evgTrigEvt.cpp
+++ b/evgMrmApp/src/evgTrigEvt.cpp
@@ -11,10 +11,12 @@
 #include "evgRegMap.h"
 
 evgTrigEvt::evgTrigEvt(const std::string& name, const epicsUInt32 id,
-                       volatile epicsUInt8* const pReg):
-mrf::ObjectInst<evgTrigEvt>(name),
-m_id(id),
-m_pReg(pReg) {
+                       volatile epicsUInt8* const pReg)
+    :mrf::ObjectInst<evgTrigEvt>(name)
+    ,m_id(id)
+    ,m_pReg(pReg)
+{
+    OBJECT_INIT;
 }
 
 evgTrigEvt::~evgTrigEvt() {

--- a/evgMrmApp/src/evgTrigEvt.h
+++ b/evgMrmApp/src/evgTrigEvt.h
@@ -5,6 +5,7 @@
 #include "mrf/object.h"
 
 class evgTrigEvt : public mrf::ObjectInst<evgTrigEvt> {
+    OBJECT_DECL(evgTrigEvt);
 public:
     evgTrigEvt(const std::string&, const epicsUInt32, volatile epicsUInt8* const);
     ~evgTrigEvt();

--- a/evgMrmApp/src/fct.cpp
+++ b/evgMrmApp/src/fct.cpp
@@ -24,6 +24,8 @@ FCT::FCT(evgMrm *evg, const std::string& id, volatile epicsUInt8* const base)
     ,base(base)
     ,sfp(8)
 {
+    OBJECT_INIT;
+
     for(size_t i=0; i<sfp.size(); i++) {
         std::ostringstream name;
         name<<id<<":SFP"<<(i+1); // manual numbers SFP from 1

--- a/evgMrmApp/src/fct.h
+++ b/evgMrmApp/src/fct.h
@@ -18,6 +18,7 @@ class SFP;
 // Fanout/ConcenTrator
 class FCT : public mrf::ObjectInst<FCT>
 {
+    OBJECT_DECL(FCT);
     evgMrm *evg;
     volatile epicsUInt8* const base;
     std::vector<SFP*> sfp;

--- a/evrApp/src/Makefile
+++ b/evrApp/src/Makefile
@@ -5,12 +5,15 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+USR_CPPFLAGS += -DBUILDING_EVR_API
+
 LIBRARY = evr
 
 SRC_DIRS += evr
 
 DBD += evrSupport.dbd
 
+INC += evr/evrAPI.h
 INC += evr/pulser.h
 INC += evr/output.h
 INC += evr/delay.h

--- a/evrApp/src/evr.cpp
+++ b/evrApp/src/evr.cpp
@@ -31,6 +31,13 @@
  * fail in some cases.
  */
 
+EVR::EVR(const std::string& n, bus_configuration& busConfig)
+    :mrf::ObjectInst<EVR>(n)
+    ,busConfiguration(busConfig)
+{
+    OBJECT_INIT;
+}
+
 EVR::~EVR()
 {
 }
@@ -69,24 +76,61 @@ std::string EVR::position() const
     return position.str();
 }
 
+Pulser::Pulser(const std::string& n)
+    :mrf::ObjectInst<Pulser>(n)
+{
+    OBJECT_INIT;
+}
+
 Pulser::~Pulser()
 {
+}
+
+Output::Output(const std::string& n)
+    :mrf::ObjectInst<Output>(n)
+{
+    OBJECT_INIT;
 }
 
 Output::~Output()
 {
 }
 
+Input::Input(const std::string& n)
+    :mrf::ObjectInst<Input>(n)
+{
+    OBJECT_INIT;
+}
+
 Input::~Input()
 {
 }
+
+PreScaler::PreScaler(const std::string& n, EVR& o)
+    :mrf::ObjectInst<PreScaler>(n)
+    ,owner(o)
+{
+    OBJECT_INIT;
+};
 
 PreScaler::~PreScaler()
 {
 }
 
+CML::CML(const std::string& n)
+    :mrf::ObjectInst<CML>(n)
+{
+    OBJECT_INIT;
+}
+
 CML::~CML()
 {
+}
+
+DelayModuleEvr::DelayModuleEvr(const std::string& n)
+    :mrf::ObjectInst<DelayModuleEvr>(n)
+{
+    OBJECT_INIT;
 }
 
 DelayModuleEvr::~DelayModuleEvr()

--- a/evrApp/src/evr.cpp
+++ b/evrApp/src/evr.cpp
@@ -31,7 +31,7 @@
  * fail in some cases.
  */
 
-EVR::EVR(const std::string& n, bus_configuration& busConfig)
+EVR::EVR(const std::string& n, const bus_configuration& busConfig)
     :mrf::ObjectInst<EVR>(n)
     ,busConfiguration(busConfig)
 {

--- a/evrApp/src/evr/cml.h
+++ b/evrApp/src/evr/cml.h
@@ -12,6 +12,7 @@
 #define CMLSHORT_HPP_INC
 
 #include "mrf/object.h"
+#include "evr/evrAPI.h"
 
 #include <epicsTypes.h>
 
@@ -24,6 +25,7 @@ enum cmlMode {
 
 class EVR_API CML : public mrf::ObjectInst<CML>
 {
+    OBJECT_DECL(CML);
 public:
   enum pattern {
     patternWaveform,
@@ -33,7 +35,7 @@ public:
     patternLow
   };
 
-  explicit CML(const std::string& n) : mrf::ObjectInst<CML>(n) {}
+  explicit CML(const std::string& n);
   virtual ~CML()=0;
 
   virtual cmlMode mode() const=0;

--- a/evrApp/src/evr/cml.h
+++ b/evrApp/src/evr/cml.h
@@ -22,7 +22,7 @@ enum cmlMode {
   cmlModeInvalid
 };
 
-class epicsShareClass CML : public mrf::ObjectInst<CML>
+class EVR_API CML : public mrf::ObjectInst<CML>
 {
 public:
   enum pattern {

--- a/evrApp/src/evr/delay.h
+++ b/evrApp/src/evr/delay.h
@@ -7,14 +7,16 @@
 #define DELAY_H
 
 #include "mrf/object.h"
+#include "evr/evrAPI.h"
 
 #include <epicsGuard.h>
 #include <epicsTypes.h>
 
 class EVR_API DelayModuleEvr : public mrf::ObjectInst<DelayModuleEvr>
 {
+    OBJECT_DECL(DelayModuleEvr);
 public:
-    explicit DelayModuleEvr(const std::string& n) : mrf::ObjectInst<DelayModuleEvr>(n) {}
+    explicit DelayModuleEvr(const std::string& n);
 	virtual ~DelayModuleEvr() = 0;
 
 	virtual void setDelay0(double val)=0;

--- a/evrApp/src/evr/delay.h
+++ b/evrApp/src/evr/delay.h
@@ -11,7 +11,7 @@
 #include <epicsGuard.h>
 #include <epicsTypes.h>
 
-class epicsShareClass DelayModuleEvr : public mrf::ObjectInst<DelayModuleEvr>
+class EVR_API DelayModuleEvr : public mrf::ObjectInst<DelayModuleEvr>
 {
 public:
     explicit DelayModuleEvr(const std::string& n) : mrf::ObjectInst<DelayModuleEvr>(n) {}

--- a/evrApp/src/evr/evr.h
+++ b/evrApp/src/evr/evr.h
@@ -17,6 +17,7 @@
 #include <callback.h>
 #include <dbScan.h>
 
+#include "evr/evrAPI.h"
 #include "evr/output.h"
 #include "mrf/object.h"
 
@@ -42,7 +43,7 @@ enum TSSource {
  * Device support can use one of the functions returning IOSCANPVT
  * to impliment get_ioint_info().
  */
-class epicsShareClass EVR : public mrf::ObjectInst<EVR>
+class EVR_API EVR : public mrf::ObjectInst<EVR>
 {
 public:
   EVR(const std::string& n, bus_configuration& busConfig) : mrf::ObjectInst<EVR>(n), busConfiguration(busConfig) {}

--- a/evrApp/src/evr/evr.h
+++ b/evrApp/src/evr/evr.h
@@ -45,6 +45,8 @@ enum TSSource {
  */
 class EVR_API EVR : public mrf::ObjectInst<EVR>
 {
+    EVR(const EVR&);
+    EVR& operator=(const EVR&);
 public:
   EVR(const std::string& n, bus_configuration& busConfig) : mrf::ObjectInst<EVR>(n), busConfiguration(busConfig) {}
 

--- a/evrApp/src/evr/evr.h
+++ b/evrApp/src/evr/evr.h
@@ -47,8 +47,9 @@ class EVR_API EVR : public mrf::ObjectInst<EVR>
 {
     EVR(const EVR&);
     EVR& operator=(const EVR&);
+    OBJECT_DECL(EVR);
 public:
-  EVR(const std::string& n, bus_configuration& busConfig) : mrf::ObjectInst<EVR>(n), busConfiguration(busConfig) {}
+  EVR(const std::string& n, bus_configuration& busConfig);
 
   virtual ~EVR()=0;
 

--- a/evrApp/src/evr/evr.h
+++ b/evrApp/src/evr/evr.h
@@ -49,7 +49,7 @@ class EVR_API EVR : public mrf::ObjectInst<EVR>
     EVR& operator=(const EVR&);
     OBJECT_DECL(EVR);
 public:
-  EVR(const std::string& n, bus_configuration& busConfig);
+  EVR(const std::string& n, const bus_configuration &busConfig);
 
   virtual ~EVR()=0;
 

--- a/evrApp/src/evr/evrAPI.h
+++ b/evrApp/src/evr/evrAPI.h
@@ -1,0 +1,46 @@
+#ifndef INC_evrAPI_h
+#define INC_evrAPI_h
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+/* Prior to 3.15, the signal for a DLL build was inverted */
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_EVR_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define EVR_API __declspec(dllexport)
+#  elif !defined(BUILDING_EVR_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define EVR_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define EVR_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(EVR_API)
+#  define EVR_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_evrAPI_h */

--- a/evrApp/src/evr/input.h
+++ b/evrApp/src/evr/input.h
@@ -24,8 +24,9 @@ enum TrigMode {
 
 class EVR_API Input : public mrf::ObjectInst<Input>
 {
+    OBJECT_DECL(Input);
 public:
-  explicit Input(const std::string& n) : mrf::ObjectInst<Input>(n) {}
+  explicit Input(const std::string& n);
   virtual ~Input()=0;
 
   //! Set mask of dbus bits are driven by this input

--- a/evrApp/src/evr/input.h
+++ b/evrApp/src/evr/input.h
@@ -12,6 +12,7 @@
 #define INPUT_HPP_INC
 
 #include "mrf/object.h"
+#include "evr/evrAPI.h"
 
 #include <epicsTypes.h>
 
@@ -21,7 +22,7 @@ enum TrigMode {
   TrigEdge=2
 };
 
-class epicsShareClass Input : public mrf::ObjectInst<Input>
+class EVR_API Input : public mrf::ObjectInst<Input>
 {
 public:
   explicit Input(const std::string& n) : mrf::ObjectInst<Input>(n) {}

--- a/evrApp/src/evr/output.h
+++ b/evrApp/src/evr/output.h
@@ -23,7 +23,7 @@ enum OutputType {
   OutputBackplane=4, //!< Backplane lines
 };
 
-class epicsShareClass Output : public mrf::ObjectInst<Output>
+class EVR_API Output : public mrf::ObjectInst<Output>
 {
 public:
   explicit Output(const std::string& n) : mrf::ObjectInst<Output>(n) {}

--- a/evrApp/src/evr/output.h
+++ b/evrApp/src/evr/output.h
@@ -15,6 +15,8 @@
 
 #include <epicsTypes.h>
 
+#include <evr/evrAPI.h>
+
 enum OutputType {
   OutputInt=0, //!< Internal
   OutputFP=1,  //!< Front Panel
@@ -25,8 +27,9 @@ enum OutputType {
 
 class EVR_API Output : public mrf::ObjectInst<Output>
 {
+    OBJECT_DECL(Output);
 public:
-  explicit Output(const std::string& n) : mrf::ObjectInst<Output>(n) {}
+  explicit Output(const std::string& n);
   virtual ~Output()=0;
 
   /**\defgroup src Control which source(s) effect this output.

--- a/evrApp/src/evr/prescaler.h
+++ b/evrApp/src/evr/prescaler.h
@@ -17,7 +17,7 @@
 
 class EVR;
 
-class epicsShareClass PreScaler : public mrf::ObjectInst<PreScaler>
+class EVR_API PreScaler : public mrf::ObjectInst<PreScaler>
 {
 public:
   PreScaler(const std::string& n, EVR& o):mrf::ObjectInst<PreScaler>(n),owner(o){};

--- a/evrApp/src/evr/prescaler.h
+++ b/evrApp/src/evr/prescaler.h
@@ -14,13 +14,15 @@
 #include <epicsTypes.h>
 
 #include "mrf/object.h"
+#include "evr/evrAPI.h"
 
 class EVR;
 
 class EVR_API PreScaler : public mrf::ObjectInst<PreScaler>
 {
+    OBJECT_DECL(PreScaler);
 public:
-  PreScaler(const std::string& n, EVR& o):mrf::ObjectInst<PreScaler>(n),owner(o){};
+  PreScaler(const std::string& n, EVR& o);
   virtual ~PreScaler()=0;
 
   virtual epicsUInt32 prescaler() const=0;

--- a/evrApp/src/evr/pulser.h
+++ b/evrApp/src/evr/pulser.h
@@ -38,8 +38,9 @@ struct MapType {
  */
 class EVR_API Pulser : public mrf::ObjectInst<Pulser>
 {
+    OBJECT_DECL(Pulser);
 public:
-  explicit Pulser(const std::string& n) : mrf::ObjectInst<Pulser>(n) {}
+  explicit Pulser(const std::string& n);
   virtual ~Pulser()=0;
 
   /**\defgroup ena Enable/disable pulser output.

--- a/evrApp/src/evr/pulser.h
+++ b/evrApp/src/evr/pulser.h
@@ -12,6 +12,7 @@
 #define PULSER_HPP_INC
 
 #include "mrf/object.h"
+#include "evr/evrAPI.h"
 
 #include <epicsTypes.h>
 
@@ -35,7 +36,7 @@ struct MapType {
  * Gated mode has two event codes.  One is sets the output
  * high and the second resets the output low.
  */
-class epicsShareClass Pulser : public mrf::ObjectInst<Pulser>
+class EVR_API Pulser : public mrf::ObjectInst<Pulser>
 {
 public:
   explicit Pulser(const std::string& n) : mrf::ObjectInst<Pulser>(n) {}

--- a/evrApp/src/evrGTIF.cpp
+++ b/evrApp/src/evrGTIF.cpp
@@ -41,7 +41,7 @@ static EVR* lastSrc = 0;
 
 static epicsMutexId lastLock;
 
-epicsShareFunc
+EVR_API
 int EVRInitTime()
 {
     if(lastLock)

--- a/evrApp/src/evrGTIF.h
+++ b/evrApp/src/evrGTIF.h
@@ -13,7 +13,7 @@
 
 #include <epicsTypes.h>
 #include <epicsTime.h>
-#include <shareLib.h>
+#include <evr/evrAPI.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,13 +26,13 @@ extern "C" {
  */
 
 /* Must be called before other functions.  Returns non-zero on error */
-epicsShareFunc
+EVR_API
 int EVRInitTime();
 
-epicsShareFunc
+EVR_API
 int EVRCurrentTime(epicsTimeStamp *pDest);
 
-epicsShareFunc
+EVR_API
 int EVREventTime(epicsTimeStamp *pDest, int event);
 
 #ifdef __cplusplus

--- a/evrApp/src/ntpShm.cpp
+++ b/evrApp/src/ntpShm.cpp
@@ -97,7 +97,7 @@ typedef struct {
 
     epicsMutexId ntplock;
 
-    CALLBACK ntpcb;
+    callbackPvt ntpcb;
 
     epicsUInt32 event;
 
@@ -196,7 +196,7 @@ static void ntpshmupdate(void*, epicsUInt32 event)
     return; // normal exit
 }
 
-static void ntpsetup(CALLBACK *)
+static void ntpsetup(callbackPvt *)
 {
     // We don't set IPC_CREAT, but instead wait for NTPD to start and initialize
     // as it wants

--- a/evrFRIBApp/src/evr_frib.cpp
+++ b/evrFRIBApp/src/evr_frib.cpp
@@ -46,6 +46,8 @@ EVRFRIB::EVRFRIB(const std::string& s,
     ,out_pulse1(SB()<<s<<":OUT:TR"<<1, 3, this)
     ,mappings(256)
 {
+    OBJECT_INIT;
+
     epicsUInt32 info = LE_READ32(base, FWInfo);
 
     switch((info&FWInfo_Flavor_mask)>>FWInfo_Flavor_shift) {

--- a/evrFRIBApp/src/evr_frib.h
+++ b/evrFRIBApp/src/evr_frib.h
@@ -87,6 +87,7 @@ struct PulserFRIB : public Pulser
 struct EVRFRIB : public mrf::ObjectInst<EVRFRIB, EVR>
 {
     typedef mrf::ObjectInst<EVRFRIB, EVR> base_t;
+    OBJECT_DECL(EVRFRIB);
 
     mutable epicsMutex mutex;
 

--- a/evrMrmApp/src/Makefile
+++ b/evrMrmApp/src/Makefile
@@ -5,6 +5,7 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+USR_CPPFLAGS += -DBUILDING_EVRMRM_API
 USR_INCLUDES += -I$(TOP)/mrmShared/src
 USR_INCLUDES += -I$(TOP)/mrfCommon/src
 
@@ -57,4 +58,3 @@ endif
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
-

--- a/evrMrmApp/src/Makefile
+++ b/evrMrmApp/src/Makefile
@@ -48,6 +48,7 @@ evrMrm_LIBS += mrfCommon mrmShared evr epicspci epicsvme $(EPICS_BASE_IOC_LIBS)
 
 DBD += drvemSupport.dbd
 
+USR_SYS_LIBS_WIN32 += ws2_32
 ifneq ($(DEVIOCSTATS),)
 evrmrm_DBD += devIocStats.dbd
 evrmrm_LIBS += devIocStats

--- a/evrMrmApp/src/bufrxmgr.cpp
+++ b/evrMrmApp/src/bufrxmgr.cpp
@@ -148,7 +148,7 @@ bufRxManager::receive(epicsUInt8* raw,unsigned int usedlen)
 }
 
 void
-bufRxManager::received(CALLBACK* cb)
+bufRxManager::received(callbackPvt* cb)
 {
     void *vptr;
     callbackGetUser(vptr,cb);

--- a/evrMrmApp/src/bufrxmgr.h
+++ b/evrMrmApp/src/bufrxmgr.h
@@ -17,8 +17,9 @@
 #include <callback.h>
 
 #include "mrf/databuf.h"
+#include "evrMrmAPI.h"
 
-class epicsShareClass bufRxManager : public dataBufRx
+class EVRMRM_API bufRxManager : public dataBufRx
 {
 public:
     bufRxManager(const std::string&, unsigned int qdepth, unsigned int bsize=0);

--- a/evrMrmApp/src/bufrxmgr.h
+++ b/evrMrmApp/src/bufrxmgr.h
@@ -15,9 +15,6 @@
 
 #include <ellLib.h>
 #include <callback.h>
-#include "mrf/databuf.h"
-
-
 
 #include "mrf/databuf.h"
 

--- a/evrMrmApp/src/bufrxmgr.h
+++ b/evrMrmApp/src/bufrxmgr.h
@@ -75,8 +75,8 @@ private:
     ELLLIST freebufs;
     ELLLIST usedbufs;
 
-    CALLBACK received_cb;
-    static void received(CALLBACK*);
+    callbackPvt received_cb;
+    static void received(callbackPvt*);
 
     struct buffer {
         ELLNODE node;

--- a/evrMrmApp/src/devMrmBuf.h
+++ b/evrMrmApp/src/devMrmBuf.h
@@ -13,6 +13,7 @@
 #define DEVMRMBUF_H_
 
 #include <epicsTypes.h>
+#include <evrMrmAPI.h>
 
 /**
  * @brief The buffer information data structure
@@ -49,7 +50,7 @@ extern "C" {
  *
  * @return Returns the structure pointer on success and NULL on failure.
  */
-mrmBufferInfo_t epicsShareFunc *mrmBufInit(const char *dev_name);
+mrmBufferInfo_t EVRMRM_API *mrmBufInit(const char *dev_name);
 
 /**
  * @brief Checks whether receive buffer is supported.
@@ -62,7 +63,7 @@ mrmBufferInfo_t epicsShareFunc *mrmBufInit(const char *dev_name);
  *
  * @return Returns 1 if supported, 0 if not and -1 if data is NULL.
  */
-epicsStatus epicsShareFunc mrmBufRxSupported(mrmBufferInfo_t *data);
+epicsStatus EVRMRM_API mrmBufRxSupported(mrmBufferInfo_t *data);
 
 /**
  * @brief Checks whether transferring buffer is supported.
@@ -75,7 +76,7 @@ epicsStatus epicsShareFunc mrmBufRxSupported(mrmBufferInfo_t *data);
  *
  * @return Returns 1 if supported, 0 if not and -1 if data is NULL.
  */
-epicsStatus epicsShareFunc mrmBufTxSupported(mrmBufferInfo_t *data);
+epicsStatus EVRMRM_API mrmBufTxSupported(mrmBufferInfo_t *data);
 
 /**
  * @brief Disable buffer sending logic.
@@ -88,7 +89,7 @@ epicsStatus epicsShareFunc mrmBufTxSupported(mrmBufferInfo_t *data);
  *
  * @return Returns 0 on success -1 on failure.
  */
-epicsStatus epicsShareFunc mrmBufEnable(mrmBufferInfo_t *data);
+epicsStatus EVRMRM_API mrmBufEnable(mrmBufferInfo_t *data);
 
 /**
  * @brief Disable buffer sending logic.
@@ -99,7 +100,7 @@ epicsStatus epicsShareFunc mrmBufEnable(mrmBufferInfo_t *data);
  *
  * @return Returns 0 on success -1 on failure.
  */
-epicsStatus epicsShareFunc mrmBufDisable(mrmBufferInfo_t *data);
+epicsStatus EVRMRM_API mrmBufDisable(mrmBufferInfo_t *data);
 
 /**
  * @brief Get maximum supported buffer length.
@@ -109,7 +110,7 @@ epicsStatus epicsShareFunc mrmBufDisable(mrmBufferInfo_t *data);
  *
  * @return Returns 0 on success -1 on failure.
  */
-epicsStatus epicsShareFunc mrmBufMaxLen(mrmBufferInfo_t *data, epicsUInt32 *maxLength);
+epicsStatus EVRMRM_API mrmBufMaxLen(mrmBufferInfo_t *data, epicsUInt32 *maxLength);
 
 /**
  * @brief Send buffer data
@@ -122,7 +123,7 @@ epicsStatus epicsShareFunc mrmBufMaxLen(mrmBufferInfo_t *data, epicsUInt32 *maxL
  *
  * @return Returns 0 on success -1 on failure.
  */
-epicsStatus epicsShareFunc mrmBufSend(mrmBufferInfo_t *data, epicsUInt32 len, epicsUInt8 *buf);
+epicsStatus EVRMRM_API mrmBufSend(mrmBufferInfo_t *data, epicsUInt32 len, epicsUInt8 *buf);
 
 /**
  * @brief Register data receive callback function
@@ -133,7 +134,7 @@ epicsStatus epicsShareFunc mrmBufSend(mrmBufferInfo_t *data, epicsUInt32 len, ep
  *
  * @return Returns 0 on success -1 on failure.
  */
-epicsStatus epicsShareFunc mrmBufRegCallback(mrmBufferInfo_t *data, mrmBufRecievedCallback callback, void *param);
+epicsStatus EVRMRM_API mrmBufRegCallback(mrmBufferInfo_t *data, mrmBufRecievedCallback callback, void *param);
 
 #ifdef __cplusplus
 }

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -156,6 +156,8 @@ EVRMRM::EVRMRM(const std::string& n,
   ,lastValidTimestamp(0)
 {
 try{
+    OBJECT_INIT;
+
     const epicsUInt32 rawver = fpgaFirmware();
     const epicsUInt32 boardtype = (rawver&FWVersion_type_mask)>>FWVersion_type_shift;
     const epicsUInt32 formfactor = (rawver&FWVersion_form_mask)>>FWVersion_form_shift;

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1397,7 +1397,7 @@ EVRMRM::drain_fifo()
 }
 
 void
-EVRMRM::sentinel_done(CALLBACK* cb)
+EVRMRM::sentinel_done(callbackPvt* cb)
 {
 try {
     void *vptr;
@@ -1423,7 +1423,7 @@ try {
 }
 
 void
-EVRMRM::poll_link(CALLBACK* cb)
+EVRMRM::poll_link(callbackPvt* cb)
 {
 try {
     void *vptr;
@@ -1460,7 +1460,7 @@ try {
 }
 
 static
-void send_timestamp(CALLBACK *cb)
+void send_timestamp(callbackPvt *cb)
 {
     void *raw;
     callbackGetUser(raw, cb);

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -89,6 +89,7 @@ class EVRMRM_API EVRMRM : public mrf::ObjectInst<EVRMRM, EVR>,
                                public TimeStampSource
 {
     typedef mrf::ObjectInst<EVRMRM, EVR> base_t;
+    OBJECT_DECL(EVRMRM);
 public:
     /** @brief Guards access to instance
    *  All callers must take this lock before any operations on

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -68,7 +68,7 @@ struct eventCode {
     typedef std::list<std::pair<EVR::eventCallback,void*> > notifiees_t;
     notifiees_t notifiees;
 
-    CALLBACK done;
+    callbackPvt done;
     size_t waitingfor;
     bool again;
 
@@ -278,18 +278,18 @@ private:
     epicsThreadRunableMethod<EVRMRM, &EVRMRM::drain_fifo> drain_fifo_method;
     epicsThread drain_fifo_task;
     epicsMessageQueue drain_fifo_wakeup;
-    static void sentinel_done(CALLBACK*);
+    static void sentinel_done(callbackPvt*);
 
     epicsUInt32 count_FIFO_sw_overrate;
 
     eventCode events[256];
 
     // Buffer received
-    CALLBACK data_rx_cb;
+    callbackPvt data_rx_cb;
 
     // Periodic callback to detect when link state goes from down to up
-    CALLBACK poll_link_cb;
-    static void poll_link(CALLBACK*);
+    callbackPvt poll_link_cb;
+    static void poll_link(callbackPvt*);
 
     enum timeSrcMode_t {
         Disable,  // do nothing
@@ -300,7 +300,7 @@ private:
      *   timeSrcMode!=Disable -> listen for 125, react by sending shift 0/1 codes
      *   timeSrcMode==SysClk  -> send soft 125 events
      */
-    CALLBACK timeSrc_cb;
+    callbackPvt timeSrc_cb;
 
     // Set by clockTSSet() with IRQ disabled
     double stampClock;

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -44,6 +44,7 @@
 #include "mrmDataBufTx.h"
 #include "sfp.h"
 #include "configurationInfo.h"
+#include <evrMrmAPI.h>
 
 class EVRMRM;
 
@@ -83,7 +84,7 @@ struct eventCode {
  *
  * 
  */
-class epicsShareClass EVRMRM : public mrf::ObjectInst<EVRMRM, EVR>,
+class EVRMRM_API EVRMRM : public mrf::ObjectInst<EVRMRM, EVR>,
                                public MRMSPI,
                                public TimeStampSource
 {

--- a/evrMrmApp/src/drvemIocsh.h
+++ b/evrMrmApp/src/drvemIocsh.h
@@ -12,7 +12,7 @@
 #define EVRMRMIOCSH_H
 
 #include <initHooks.h>
-#include <shareLib.h>
+#include <evrMrmAPI.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,28 +30,28 @@ extern "C" {
  * 3 - All "write" (output record processing)
  * 4 - Some "read" (input record processing) and IRQ
  */
-epicsShareExtern int evrmrmVerb;
+EVRMRM_API extern int evrmrmVerb;
 
 
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrSetupPCI(const char* id, const char* pcispec);
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrSetupVME(const char* id,int slot,int base,int level, int vector);
 
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrDumpMap(const char* id,int evt,int ram);
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrForward(const char* id, const char* events_iocsh);
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrLoopback(const char* id, int rxLoopback, int txLoopback);
 
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrInithooks(initHookState state);
 
-long epicsShareFunc
+long EVRMRM_API
 mrmEvrReport(int level);
 
-void epicsShareFunc
+void EVRMRM_API
 mrmEvrProbe(const char *id);
 
 #ifdef __cplusplus

--- a/evrMrmApp/src/drvemOutput.cpp
+++ b/evrMrmApp/src/drvemOutput.cpp
@@ -26,6 +26,7 @@ MRMOutput::MRMOutput(const std::string& n, EVRMRM* o, OutputType t, unsigned int
     ,N(idx)
     ,isEnabled(true)
 {
+    OBJECT_INIT;
     shadowSource = sourceInternal();
 }
 

--- a/evrMrmApp/src/drvemOutput.h
+++ b/evrMrmApp/src/drvemOutput.h
@@ -26,6 +26,7 @@ class EVRMRM;
 class MRMOutput : public mrf::ObjectInst<MRMOutput, Output>
 {
     typedef mrf::ObjectInst<MRMOutput, Output> base_t;
+    OBJECT_DECL(MRMOutput);
 public:
   MRMOutput(const std::string& n, EVRMRM* owner, OutputType t, unsigned int idx);
   virtual ~MRMOutput();

--- a/evrMrmApp/src/drvemPrescaler.cpp
+++ b/evrMrmApp/src/drvemPrescaler.cpp
@@ -23,7 +23,9 @@
 MRMPreScaler::MRMPreScaler(const std::string& n, EVR& o,volatile unsigned char* b)
     :base_t(n,o)
     ,base(b)
-{}
+{
+    OBJECT_INIT;
+}
 
 MRMPreScaler::~MRMPreScaler() {}
 

--- a/evrMrmApp/src/drvemPrescaler.h
+++ b/evrMrmApp/src/drvemPrescaler.h
@@ -17,6 +17,7 @@
 class EVRMRM_API MRMPreScaler : public mrf::ObjectInst<MRMPreScaler,PreScaler>
 {
     typedef mrf::ObjectInst<MRMPreScaler,PreScaler> base_t;
+    OBJECT_DECL(MRMPreScaler);
     volatile unsigned char* base;
 
 public:

--- a/evrMrmApp/src/drvemPrescaler.h
+++ b/evrMrmApp/src/drvemPrescaler.h
@@ -12,8 +12,9 @@
 #define MRMEVRPRESCALER_H_INC
 
 #include <evr/prescaler.h>
+#include <evrMrmAPI.h>
 
-class epicsShareClass MRMPreScaler : public mrf::ObjectInst<MRMPreScaler,PreScaler>
+class EVRMRM_API MRMPreScaler : public mrf::ObjectInst<MRMPreScaler,PreScaler>
 {
     typedef mrf::ObjectInst<MRMPreScaler,PreScaler> base_t;
     volatile unsigned char* base;

--- a/evrMrmApp/src/drvemPulser.cpp
+++ b/evrMrmApp/src/drvemPulser.cpp
@@ -33,6 +33,8 @@ MRMPulser::MRMPulser(const std::string& n, epicsUInt32 i, EVRMRM& o)
     if(id>31)
         throw std::out_of_range("pulser id is out of range");
 
+    OBJECT_INIT;
+
     std::memset(&this->mapped, 0, NELEMENTS(this->mapped));
 }
 

--- a/evrMrmApp/src/drvemPulser.h
+++ b/evrMrmApp/src/drvemPulser.h
@@ -20,6 +20,7 @@ class EVRMRM;
 class MRMPulser : public mrf::ObjectInst<MRMPulser, Pulser>
 {
     typedef mrf::ObjectInst<MRMPulser, Pulser> base_t;
+    OBJECT_DECL(MRMPulser);
     const epicsUInt32 id;
     EVRMRM& owner;
 

--- a/evrMrmApp/src/drvemRxBuf.cpp
+++ b/evrMrmApp/src/drvemRxBuf.cpp
@@ -14,10 +14,6 @@
 #include <cstdio>
 #include <errlog.h>
 
-#ifdef _WIN32
-	#include <Winsock2.h>
-	#pragma comment (lib, "Ws2_32.lib")
-#endif
 #include <callback.h>
 #include <mrfCommonIO.h>
 #include <mrfBitOps.h>

--- a/evrMrmApp/src/drvemRxBuf.cpp
+++ b/evrMrmApp/src/drvemRxBuf.cpp
@@ -67,7 +67,7 @@ mrmBufRx::dataRxEnable(bool v)
 extern int evrMrmSeqRxDebug;
 
 void
-mrmBufRx::drainbuf(CALLBACK* cb)
+mrmBufRx::drainbuf(callbackPvt* cb)
 {
 try {
     void *vptr;

--- a/evrMrmApp/src/drvemRxBuf.h
+++ b/evrMrmApp/src/drvemRxBuf.h
@@ -28,7 +28,7 @@ public:
     virtual bool dataRxEnabled() const OVERRIDE FINAL;
     virtual void dataRxEnable(bool) OVERRIDE FINAL;
 
-    static void drainbuf(CALLBACK*);
+    static void drainbuf(callbackPvt*);
 
 protected:
     volatile unsigned char * const base;

--- a/evrMrmApp/src/drvemRxBuf.h
+++ b/evrMrmApp/src/drvemRxBuf.h
@@ -15,7 +15,7 @@
 
 #include "bufrxmgr.h"
 
-class epicsShareClass mrmBufRx : public bufRxManager
+class EVRMRM_API mrmBufRx : public bufRxManager
 {
 public:
     mrmBufRx(const std::string&, volatile void *base,unsigned int qdepth, unsigned int bsize=0);

--- a/evrMrmApp/src/drvemTSBuffer.cpp
+++ b/evrMrmApp/src/drvemTSBuffer.cpp
@@ -4,6 +4,8 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
+#include <algorithm>
+
 #include "drvem.h"
 #include "drvemTSBuffer.h"
 #include "devObj.h"

--- a/evrMrmApp/src/drvemTSBuffer.cpp
+++ b/evrMrmApp/src/drvemTSBuffer.cpp
@@ -18,6 +18,8 @@ EVRMRMTSBuffer::EVRMRMTSBuffer(const std::string &n, EVRMRM *evr)
     ,flushEvt(0u)
     ,active(0u)
 {
+    OBJECT_INIT;
+
     scanIoInit(&scan);
 }
 

--- a/evrMrmApp/src/drvemTSBuffer.h
+++ b/evrMrmApp/src/drvemTSBuffer.h
@@ -18,6 +18,7 @@ class EVRMRM;
 struct EVRMRMTSBuffer : public mrf::ObjectInst<EVRMRMTSBuffer>
 {
     typedef mrf::ObjectInst<EVRMRMTSBuffer> base_t;
+    OBJECT_DECL(EVRMRMTSBuffer);
 
     explicit EVRMRMTSBuffer(const std::string& n, EVRMRM* evr);
     virtual ~EVRMRMTSBuffer();

--- a/evrMrmApp/src/evrMrmAPI.h
+++ b/evrMrmApp/src/evrMrmAPI.h
@@ -1,0 +1,46 @@
+#ifndef INC_evrMrmAPI_h
+#define INC_evrMrmAPI_h
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+/* Prior to 3.15, the signal for a DLL build was inverted */
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_EVRMRM_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define EVRMRM_API __declspec(dllexport)
+#  elif !defined(BUILDING_EVRMRM_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define EVRMRM_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define EVRMRM_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(EVRMRM_API)
+#  define EVRMRM_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_evrMrmAPI_h */

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -13,7 +13,7 @@
 #define EVRREGMAP_H
 
 #include <mrfBitOps.h>
-#include <shareLib.h> /* for INLINE (C only) */
+#include <evrMrmAPI.h> /* for INLINE (C only) */
 
 #ifdef __cplusplus
 #  ifndef INLINE

--- a/evrMrmApp/src/evrdump.c
+++ b/evrMrmApp/src/evrdump.c
@@ -17,9 +17,10 @@
 #include <devLibPCI.h>
 
 #include "mrmpci.h"
+#include "evrMrmAPI.h"
 
 #ifndef _WIN32
-epicsShareFunc void devLibPCIRegisterBaseDefault(void);
+EVRMRM_API void devLibPCIRegisterBaseDefault(void);
 #endif
 
 static const epicsPCIID mrmevrs[] = {

--- a/mrfCommon/src/Makefile
+++ b/mrfCommon/src/Makefile
@@ -81,6 +81,7 @@ mrfCommon_LIBS += $(EPICS_BASE_IOC_LIBS)
 #OBJS_IOC += $(mrfCommon_SRCS)
 mrfCommon_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+USR_SYS_LIBS_WIN32 += ws2_32
 #---------------------
 # Build the host-side utilities for creating and analyzing
 # the fractional synthesizer control words.

--- a/mrfCommon/src/Makefile
+++ b/mrfCommon/src/Makefile
@@ -2,7 +2,7 @@ TOP=../..
 include $(TOP)/configure/CONFIG
 
 USR_CFLAGS += -DDEBUG_PRINT
-USR_CPPFLAGS += -DDEBUG_PRINT
+USR_CPPFLAGS += -DDEBUG_PRINT -DBUILDING_MRFCOMMON_API
 
 export PERL5LIB=$(EPICS_BASE)/lib/perl
 
@@ -11,6 +11,7 @@ MRF_VERSION = $(MRFIOC2_MAJOR_VERSION).$(MRFIOC2_MINOR_VERSION).$(MRFIOC2_MAINTE
 #---------------------
 # Install include files
 #
+INC += mrf/mrfCommonAPI.h
 INC += mrfBitOps.h
 INC += mrfCommon.h        # Common MRF event system constants & definitions
 INC += mrfCommonIO.h      # Common I/O access macros

--- a/mrfCommon/src/databuf.cpp
+++ b/mrfCommon/src/databuf.cpp
@@ -12,6 +12,16 @@ OBJECT_BEGIN(dataBufTx) {
     OBJECT_PROP1("Max length", &dataBufTx::lenMax);
 } OBJECT_END(dataBufTx)
 
+dataBufTx::dataBufTx(const std::string& n) : mrf::ObjectInst<dataBufTx>(n)
+{
+    OBJECT_INIT;
+}
+
+dataBufRx::dataBufRx(const std::string& n) : mrf::ObjectInst<dataBufRx>(n)
+{
+    OBJECT_INIT;
+}
+
 // definition for pure virtual is required in most cases (apparently not MSVC w/ static linking?)
 // If bottom 2 lines are removed, MSVC does not report warning C4273
 #if !defined(_WIN32) || (defined(_WIN32) && defined(_DLL))

--- a/mrfCommon/src/databuf.cpp
+++ b/mrfCommon/src/databuf.cpp
@@ -22,9 +22,5 @@ dataBufRx::dataBufRx(const std::string& n) : mrf::ObjectInst<dataBufRx>(n)
     OBJECT_INIT;
 }
 
-// definition for pure virtual is required in most cases (apparently not MSVC w/ static linking?)
-// If bottom 2 lines are removed, MSVC does not report warning C4273
-#if !defined(_WIN32) || (defined(_WIN32) && defined(_DLL))
 dataBufTx::~dataBufTx() {}
 dataBufRx::~dataBufRx() {}
-#endif

--- a/mrfCommon/src/devObj.h
+++ b/mrfCommon/src/devObj.h
@@ -90,7 +90,7 @@ struct addrBase {
     mrf::Object *O;
 };
 
-epicsShareExtern const
+MRFCOMMON_API extern const
 linkOptionEnumType readbackEnum[];
 
 template<typename T>
@@ -98,10 +98,10 @@ struct addr : public addrBase {
     mrf::auto_ptr<mrf::property<T> > P;
 };
 
-epicsShareExtern const
+MRFCOMMON_API extern const
 linkOptionDef objdef[];
 
-struct epicsShareClass CurrentRecord {
+struct MRFCOMMON_API CurrentRecord {
     template<typename Rec>
     explicit CurrentRecord(Rec* prec)
     {

--- a/mrfCommon/src/devObjString.cpp
+++ b/mrfCommon/src/devObjString.cpp
@@ -7,11 +7,8 @@
 /*
  * Author: Michael Davidsaver <mdavidsaver@gmail.com>
  */
-#ifdef _WIN32
- #define NOMINMAX
- #include <algorithm>
-#endif
 
+#include <algorithm>
 
 #include <stringoutRecord.h>
 #include <stringinRecord.h>

--- a/mrfCommon/src/flash.cpp
+++ b/mrfCommon/src/flash.cpp
@@ -4,6 +4,7 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 

--- a/mrfCommon/src/flash.cpp
+++ b/mrfCommon/src/flash.cpp
@@ -42,7 +42,7 @@ CFIFlash::readID(ID *id)
 
     {
         SPIDevice::Selector S(dev);
-        dev.interface()->cycles(1, ops);
+        dev.bus()->cycles(1, ops);
     }
 
     if(response[1]==0xff)
@@ -52,7 +52,7 @@ CFIFlash::readID(ID *id)
          * A single re-try.
          */
         SPIDevice::Selector S(dev);
-        dev.interface()->cycles(1, ops);
+        dev.bus()->cycles(1, ops);
     }
 
     id->vendor = response[1];
@@ -86,7 +86,7 @@ CFIFlash::readID(ID *id)
 
         {
             SPIDevice::Selector S(dev);
-            dev.interface()->cycles(1, ops);
+            dev.bus()->cycles(1, ops);
         }
 
         if(response[4]>2) {
@@ -98,7 +98,7 @@ CFIFlash::readID(ID *id)
             ops[1].out = &id->SN[0];
 
             SPIDevice::Selector S(dev);
-            dev.interface()->cycles(2, ops);
+            dev.bus()->cycles(2, ops);
 
             // if this byte isn't 0, then the spec isn't being followed
             if(response[6]!=0)
@@ -146,7 +146,7 @@ void CFIFlash::read(epicsUInt32 start, epicsUInt32 count, epicsUInt8 *data)
 
     {
         SPIDevice::Selector S(dev);
-        dev.interface()->cycles(2, ops);
+        dev.bus()->cycles(2, ops);
     }
 }
 
@@ -180,7 +180,7 @@ void CFIFlash::write(const epicsUInt32 start,
 
     const epicsUInt32 end = start+count;
 
-    const double timeout = dev.interface()->timeout();
+    const double timeout = dev.bus()->timeout();
 
     {
         WriteEnabler WE(*this);
@@ -202,7 +202,7 @@ void CFIFlash::write(const epicsUInt32 start,
 
             {
                 SPIDevice::Selector S(dev);
-                dev.interface()->cycles(1, &op);
+                dev.bus()->cycles(1, &op);
             }
         }
 
@@ -234,7 +234,7 @@ void CFIFlash::write(const epicsUInt32 start,
 
             {
                 SPIDevice::Selector S(dev);
-                dev.interface()->cycles(2, ops);
+                dev.bus()->cycles(2, ops);
             }
         }
 
@@ -294,7 +294,7 @@ void CFIFlash::erase(epicsUInt32 start, epicsUInt32 count, bool strict)
 
     const epicsUInt32 end = start+count;
 
-    const double timeout = dev.interface()->timeout();
+    const double timeout = dev.bus()->timeout();
 
     WriteEnabler WE(*this);
 
@@ -315,7 +315,7 @@ void CFIFlash::erase(epicsUInt32 start, epicsUInt32 count, bool strict)
 
         {
             SPIDevice::Selector S(dev);
-            dev.interface()->cycles(1, &op);
+            dev.bus()->cycles(1, &op);
         }
     }
 }
@@ -339,7 +339,7 @@ unsigned CFIFlash::status()
     SPIInterface::Operation op = {2, cmd, response};
 
     SPIDevice::Selector S(dev);
-    dev.interface()->cycles(1, &op);
+    dev.bus()->cycles(1, &op);
 
     return response[1]&0x03; // pass out only 0x01 busy and 0x02 write enabled
 }
@@ -350,7 +350,7 @@ void CFIFlash::writeEnable(bool e)
     SPIInterface::Operation op = {1, &cmd, NULL};
 
     SPIDevice::Selector S(dev);
-    dev.interface()->cycles(1, &op);
+    dev.bus()->cycles(1, &op);
 }
 
 void CFIFlash::busyWait(double timeout, unsigned n)

--- a/mrfCommon/src/flashiocsh.cpp
+++ b/mrfCommon/src/flashiocsh.cpp
@@ -63,6 +63,13 @@ void flashinfo(const char *name)
             printf("\n");
         }
 
+        if(!info.capacity || !info.sectorSize || !info.pageSize) {
+            printf("Warning: Some information about this flash chip is not known.\n"
+                   "         Please open an issue and include this output of flashinfo()\n"
+                   "         and if known the flash chip vendor and part number.\n"
+                   "         https://github.com/epics-modules/mrfioc2/issues\n");
+        }
+
         {
             mrf::CFIStreamBuf sbuf(mem);
             std::istream strm(&sbuf);

--- a/mrfCommon/src/flashiocsh.cpp
+++ b/mrfCommon/src/flashiocsh.cpp
@@ -4,6 +4,7 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 #include <fstream>

--- a/mrfCommon/src/linkoptions.c
+++ b/mrfCommon/src/linkoptions.c
@@ -20,7 +20,6 @@
 #include <epicsString.h>
 #include <macLib.h>
 
-#define epicsExportSharedSymbols
 #include "linkoptions.h"
 
 #ifndef HUGE_VALF
@@ -131,7 +130,7 @@ store_value(const linkOptionDef* opt, void* user, const char* val, int options)
 }
 
 int
-epicsShareAPI
+epicsStdCall
 linkOptionsStore(const linkOptionDef* opts, void* user, const char* str, int options)
 {
     MAC_HANDLE handle; /* only .debug is used */
@@ -220,9 +219,8 @@ errbitarray:
     return status;
 }
 
-epicsShareFunc
 const char*
-epicsShareAPI
+epicsStdCall
 linkOptionsEnumString(const linkOptionEnumType *emap, int i, const char* def)
 {
     for(; emap && emap->name; emap++) {

--- a/mrfCommon/src/linkoptions.h
+++ b/mrfCommon/src/linkoptions.h
@@ -11,7 +11,7 @@
 #ifndef LINKOPTIONS_H
 #define LINKOPTIONS_H
 
-#include <shareLib.h>
+#include <mrf/mrfCommonAPI.h>
 #include <dbDefs.h>
 #include <epicsTypes.h>
 
@@ -126,9 +126,9 @@ typedef struct linkOptionDef {
  *@return 0 Ok
  *@return -1 Fail ('user' may be partially modified)
  */
-epicsShareFunc
+MRFCOMMON_API
 int
-epicsShareAPI
+epicsStdCall
 linkOptionsStore(const linkOptionDef* opts, void* user, const char* str, int options);
 
 /**@brief Return the string associated with Enum 'i'
@@ -138,9 +138,9 @@ linkOptionsStore(const linkOptionDef* opts, void* user, const char* str, int opt
  *@param def String to be returned in 'i' isn't a valid Enum index.
  *@return A constant string
  */
-epicsShareFunc
+MRFCOMMON_API
 const char*
-epicsShareAPI
+epicsStdCall
 linkOptionsEnumString(const linkOptionEnumType *Enums, int i, const char* def);
 
 #ifdef __cplusplus

--- a/mrfCommon/src/mrf/databuf.h
+++ b/mrfCommon/src/mrf/databuf.h
@@ -25,10 +25,11 @@ typedef void (*dataBufComplete)(void *arg, epicsStatus ok,
 
 
 class MRFCOMMON_API dataBufTx : public mrf::ObjectInst<dataBufTx> {
+    OBJECT_DECL(dataBufTx);
     struct impl;
     impl *pimpl;
 public:
-    explicit dataBufTx(const std::string& n) : mrf::ObjectInst<dataBufTx>(n) {}
+    explicit dataBufTx(const std::string& n);
     virtual ~dataBufTx()=0;
 
     //! Is card configured for buffer transmission?
@@ -52,8 +53,9 @@ public:
 
 
 class MRFCOMMON_API dataBufRx : public mrf::ObjectInst<dataBufRx> {
+    OBJECT_DECL(dataBufRx);
 public:
-    explicit dataBufRx(const std::string& n) : mrf::ObjectInst<dataBufRx>(n) {}
+    explicit dataBufRx(const std::string& n);
 
     virtual ~dataBufRx()=0;
 

--- a/mrfCommon/src/mrf/databuf.h
+++ b/mrfCommon/src/mrf/databuf.h
@@ -5,15 +5,6 @@
 * mrfioc2 is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
-#ifdef DATABUF_H_INC_LEVEL2
- #ifdef epicsExportSharedSymbols
-  #define DATABUFL2_epicsExportSharedSymbols
-  #undef epicsExportSharedSymbols
-  #include "shareLib.h"
- #endif
-#endif
-
-
 #ifndef DATABUF_H_INC
 #define DATABUF_H_INC
 
@@ -21,6 +12,7 @@
 #include <epicsTime.h>
 
 #include "mrf/object.h"
+#include "mrf/mrfCommonAPI.h"
 
 /**
  *@param arg[in] Arbitrary pointer passed by user
@@ -32,7 +24,7 @@ typedef void (*dataBufComplete)(void *arg, epicsStatus ok,
                            epicsUInt32 len, const epicsUInt8* buf);
 
 
-class epicsShareClass dataBufTx : public mrf::ObjectInst<dataBufTx> {
+class MRFCOMMON_API dataBufTx : public mrf::ObjectInst<dataBufTx> {
     struct impl;
     impl *pimpl;
 public:
@@ -59,7 +51,7 @@ public:
 
 
 
-class epicsShareClass dataBufRx : public mrf::ObjectInst<dataBufRx> {
+class MRFCOMMON_API dataBufRx : public mrf::ObjectInst<dataBufRx> {
 public:
     explicit dataBufRx(const std::string& n) : mrf::ObjectInst<dataBufRx>(n) {}
 
@@ -91,9 +83,3 @@ public:
 };
 
 #endif // DATABUF_H_INC
-
-#ifdef DATABUFL2_epicsExportSharedSymbols
- #undef DATABUF_H_INC_LEVEL2
- #define epicsExportSharedSymbols
- #include "shareLib.h"
-#endif

--- a/mrfCommon/src/mrf/flash.h
+++ b/mrfCommon/src/mrf/flash.h
@@ -11,7 +11,7 @@
 #include <istream>
 
 #include <epicsTypes.h>
-#include <shareLib.h>
+#include <mrf/mrfCommonAPI.h>
 
 #include <mrfCommon.h>
 
@@ -20,7 +20,7 @@ namespace mrf {
 struct SPIDevice;
 
 //! Handling for Common Flash Interfafce compliant chips
-class epicsShareClass CFIFlash
+class MRFCOMMON_API CFIFlash
 {
 public:
     explicit CFIFlash(const SPIDevice& dev);
@@ -86,7 +86,7 @@ private:
 };
 
 //! Adapt CFIFlash for use with std::istream
-class epicsShareClass CFIStreamBuf : public std::streambuf
+class MRFCOMMON_API CFIStreamBuf : public std::streambuf
 {
     CFIFlash& flash;
     epicsUInt32 pos;
@@ -101,7 +101,7 @@ public:
 };
 
 //! Attempt to read out the header of a Xilinx bitstream file.
-struct epicsShareClass XilinxBitInfo
+struct MRFCOMMON_API XilinxBitInfo
 {
     XilinxBitInfo() {}
 

--- a/mrfCommon/src/mrf/flash.h
+++ b/mrfCommon/src/mrf/flash.h
@@ -17,7 +17,7 @@
 
 namespace mrf {
 
-struct SPIDevice;
+class SPIDevice;
 
 //! Handling for Common Flash Interfafce compliant chips
 class MRFCOMMON_API CFIFlash

--- a/mrfCommon/src/mrf/mrfCommonAPI.h
+++ b/mrfCommon/src/mrf/mrfCommonAPI.h
@@ -1,0 +1,46 @@
+#ifndef INC_mrfCommonAPI_h
+#define INC_mrfCommonAPI_h
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+/* Prior to 3.15, the signal for a DLL build was inverted */
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_MRFCOMMON_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define MRFCOMMON_API __declspec(dllexport)
+#  elif !defined(BUILDING_MRFCOMMON_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define MRFCOMMON_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define MRFCOMMON_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(MRFCOMMON_API)
+#  define MRFCOMMON_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_mrfCommonAPI_h */

--- a/mrfCommon/src/mrf/object.h
+++ b/mrfCommon/src/mrf/object.h
@@ -458,6 +458,9 @@ public:
 template<class C, typename Base = Object>
 class MRFCOMMON_API ObjectInst : public Base
 {
+    // not copyable
+    ObjectInst(const ObjectInst&);
+    ObjectInst& operator=(const ObjectInst&);
     typedef std::multimap<std::string, detail::unboundPropertyBase<C>*> m_props_t;
     static m_props_t *m_props;
 public:

--- a/mrfCommon/src/mrf/object.h
+++ b/mrfCommon/src/mrf/object.h
@@ -91,7 +91,7 @@
 #include "mrfCommon.h"
 
 // when dset should signal alarm w/o printing a message
-class epicsShareClass alarm_exception : public std::exception
+class MRFCOMMON_API alarm_exception : public std::exception
 {
     const short sevr, stat;
 public:
@@ -105,7 +105,7 @@ public:
 namespace mrf {
 
 //! @brief Requested operation is not implemented by the property
-class epicsShareClass opNotImplemented : public std::runtime_error
+class MRFCOMMON_API opNotImplemented : public std::runtime_error
 {
 public:
     explicit opNotImplemented(const std::string& m) : std::runtime_error(m) {}
@@ -117,7 +117,7 @@ public:
  * There is no way other then to up-cast in ObjectInst<C>
  * and then down-cast in getProperty<P>().
  */
-struct epicsShareClass propertyBase
+struct MRFCOMMON_API propertyBase
 {
     virtual ~propertyBase()=0;
     virtual const char* name() const=0;
@@ -192,7 +192,7 @@ struct unboundPropertyBase
 
 //! @brief An un-bound, typed scalar property
 template<class C, typename P>
-class epicsShareClass unboundProperty : public unboundPropertyBase<C>
+class MRFCOMMON_API unboundProperty : public unboundPropertyBase<C>
 {
 public:
     typedef void (C::*setter_t)(P);
@@ -219,7 +219,7 @@ makeUnboundProperty(const char* n, P (C::*g)() const, void (C::*s)(P)=0)
 
 //! @brief An un-bound, typed array property
 template<class C, typename P>
-class epicsShareClass unboundProperty<C,P[1]> : public unboundPropertyBase<C>
+class MRFCOMMON_API unboundProperty<C,P[1]> : public unboundPropertyBase<C>
 {
 public:
     typedef void   (C::*setter_t)(const P*, epicsUInt32);
@@ -248,7 +248,7 @@ makeUnboundProperty(const char* n,
 
 //! @brief An un-bound momentary/command
 template<class C>
-class epicsShareClass unboundProperty<C,void> : public unboundPropertyBase<C>
+class MRFCOMMON_API unboundProperty<C,void> : public unboundPropertyBase<C>
 {
 public:
     typedef void (C::*exec_t)();
@@ -272,7 +272,7 @@ makeUnboundProperty(const char* n,
 
 //! @brief final scalar implementation
 template<class C, typename P>
-class epicsShareClass  propertyInstance : public property<P>
+class MRFCOMMON_API  propertyInstance : public property<P>
 {
   C *inst;
   unboundProperty<C,P> prop;
@@ -313,7 +313,7 @@ unboundProperty<C,P>::bind(C* inst)
 
 //! @brief final array implementation
 template<class C, typename P>
-class epicsShareClass propertyInstance<C,P[1]> : public property<P[1]>
+class MRFCOMMON_API propertyInstance<C,P[1]> : public property<P[1]>
 {
   C *inst;
   unboundProperty<C,P[1]> prop;
@@ -342,7 +342,7 @@ unboundProperty<C,P[1]>::bind(C* inst)
 }
 
 template<class C>
-class epicsShareClass propertyInstance<C,void> : public property<void>
+class MRFCOMMON_API propertyInstance<C,void> : public property<void>
 {
     C *inst;
     unboundProperty<C,void> prop;
@@ -375,7 +375,7 @@ unboundProperty<C,void>::bind(C* inst)
  * to properties.
  */
 
-class epicsShareClass Object
+class MRFCOMMON_API Object
 {
 public:
     struct _compName {
@@ -456,7 +456,7 @@ public:
  @endcode
  */
 template<class C, typename Base = Object>
-class epicsShareClass ObjectInst : public Base
+class MRFCOMMON_API ObjectInst : public Base
 {
     typedef std::multimap<std::string, detail::unboundPropertyBase<C>*> m_props_t;
     static m_props_t *m_props;

--- a/mrfCommon/src/mrf/object.h
+++ b/mrfCommon/src/mrf/object.h
@@ -371,9 +371,10 @@ public:
     typedef std::multimap<std::string, propertyBase*> m_props_t;
 protected:
     m_props_t m_props;
-    explicit ObjectInst(const std::string& n) : Base(n) {}
     template<typename A>
-    ObjectInst(const std::string& n, A& a) : Base(n, a) {}
+    explicit ObjectInst(A& n) : Base(n) {}
+    template<typename A, typename B>
+    ObjectInst(A& n, B& a) : Base(n, a) {}
     virtual ~ObjectInst(){}
 public:
 

--- a/mrfCommon/src/mrf/pollirq.h
+++ b/mrfCommon/src/mrf/pollirq.h
@@ -4,13 +4,13 @@
 #include <epicsThread.h>
 #include <epicsEvent.h>
 #include <epicsMutex.h>
-#include <shareLib.h>
+#include <mrf/mrfCommonAPI.h>
 
 extern "C" {
     typedef void (*pollerFN)(void *);
 }
 
-class epicsShareClass IRQPoller : protected epicsThreadRunable {
+class MRFCOMMON_API IRQPoller : protected epicsThreadRunable {
 
     epicsEvent evt;
     epicsMutex lock;

--- a/mrfCommon/src/mrf/spi.h
+++ b/mrfCommon/src/mrf/spi.h
@@ -56,7 +56,7 @@ public:
     SPIDevice() :spi(0), id(0) {}
     SPIDevice(SPIInterface *spi, unsigned id) :spi(spi), id(id) {}
 
-    inline SPIInterface* interface() const { return spi; }
+    inline SPIInterface* bus() const { return spi; }
     inline unsigned selector() const { return id; }
 
     class Selector {

--- a/mrfCommon/src/mrf/spi.h
+++ b/mrfCommon/src/mrf/spi.h
@@ -12,12 +12,12 @@
 
 #include <epicsTypes.h>
 #include <epicsMutex.h>
-#include <shareLib.h>
+#include <mrf/mrfCommonAPI.h>
 
 namespace mrf {
 
 //! Interface for SPI Master
-struct epicsShareClass SPIInterface
+struct MRFCOMMON_API SPIInterface
 {
     SPIInterface();
     virtual ~SPIInterface();
@@ -48,7 +48,7 @@ private:
     double optimo;
 };
 
-class epicsShareClass SPIDevice
+class MRFCOMMON_API SPIDevice
 {
     SPIInterface * spi;
     unsigned id;

--- a/mrfCommon/src/mrfCommon.h
+++ b/mrfCommon/src/mrfCommon.h
@@ -289,7 +289,7 @@ std::ostream& operator<<(std::ostream& strm, const MRFVersion& ver);
 
 //! @brief Helper to allow one class to have several runable methods
 template<class C,void (C::*Method)()>
-class MRFCOMMON_API epicsThreadRunableMethod : public epicsThreadRunable
+class epicsThreadRunableMethod : public epicsThreadRunable
 {
     C& owner;
 public:

--- a/mrfCommon/src/mrfCommon.h
+++ b/mrfCommon/src/mrfCommon.h
@@ -87,7 +87,7 @@ using std::auto_ptr;
 
 #include  <limits.h>            /* Standard C numeric limits                                      */
 
-#include <shareLib.h>
+#include <mrf/mrfCommonAPI.h>
 
 /**************************************************************************************************/
 /*  MRF Event System Constants                                                                    */
@@ -256,7 +256,7 @@ struct SB {
  *   approacing release 12000207, we have prereleases 12FF0206, 12FE0206,
  *   12FD0206 etc. in this order.
  */
-class epicsShareClass MRFVersion
+class MRFCOMMON_API MRFVersion
 {
     const epicsUInt16 m_major;
     const epicsInt8 m_minor;
@@ -283,13 +283,13 @@ public:
     std::string str() const;
 };
 
-epicsShareExtern
+MRFCOMMON_API extern
 std::ostream& operator<<(std::ostream& strm, const MRFVersion& ver);
 
 
 //! @brief Helper to allow one class to have several runable methods
 template<class C,void (C::*Method)()>
-class epicsShareClass epicsThreadRunableMethod : public epicsThreadRunable
+class MRFCOMMON_API epicsThreadRunableMethod : public epicsThreadRunable
 {
     C& owner;
 public:
@@ -330,9 +330,9 @@ public:
 /* Round down and convert float to unsigned int
  * throws std::range_error for NaN and out of range inputs
  */
-epicsShareFunc epicsUInt32 roundToUInt(double val, epicsUInt32 maxresult=0xffffffff);
+MRFCOMMON_API epicsUInt32 roundToUInt(double val, epicsUInt32 maxresult=0xffffffff);
 
-epicsShareFunc char *allocSNPrintf(size_t N, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
+MRFCOMMON_API char *allocSNPrintf(size_t N, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
 #endif
 
 /**************************************************************************************************/
@@ -381,7 +381,7 @@ epicsShareFunc char *allocSNPrintf(size_t N, const char *fmt, ...) EPICS_PRINTF_
 #ifdef __cplusplus
 extern "C" {
 #endif
-epicsShareFunc int
+MRFCOMMON_API int
 epicsParseUInt32(const char *str, epicsUInt32 *to, int base, char **units);
 #ifdef __cplusplus
 }

--- a/mrfCommon/src/mrfFracSynth.c
+++ b/mrfCommon/src/mrfFracSynth.c
@@ -362,7 +362,7 @@ static const CorrectionValStruct  CorrectionValList [NUM_CORRECTION_VALS] = {
  *
  **************************************************************************************************/
 
-epicsShareExtern epicsStatus mrfSetEventClockSpeed (
+epicsStatus mrfSetEventClockSpeed (
     epicsFloat64   InputClockSpeed,             /* Desired event clock speed in MHz (or zero)     */
     epicsUInt32    InputControlWord,            /* Fractional synthesizer control word (or zero)  */
     epicsFloat64   ReferenceFreq,               /* SY87739L input reference frequency (in MHz)    */
@@ -549,7 +549,7 @@ epicsShareExtern epicsStatus mrfSetEventClockSpeed (
  **************************************************************************************************/
 
 
-epicsShareExtern epicsUInt32 FracSynthControlWord (
+epicsUInt32 FracSynthControlWord (
     epicsFloat64         DesiredFreq,         /* Desired output frequency                         */
     epicsFloat64         ReferenceFreq,       /* SY87739L input reference frequency               */
     epicsInt32           debugFlag,           /* Flag for debug/informational output              */
@@ -841,7 +841,7 @@ epicsShareExtern epicsUInt32 FracSynthControlWord (
  **************************************************************************************************/
 
 
-epicsShareExtern epicsFloat64 FracSynthAnalyze (
+epicsFloat64 FracSynthAnalyze (
     epicsUInt32    ControlWord,                 /* Control word to analyze                        */
     epicsFloat64   ReferenceFreq,               /* SY87739L input reference frequency             */
     epicsInt32     PrintFlag)                   /* Flag to control what we print in this routine  */

--- a/mrfCommon/src/mrfFracSynth.h
+++ b/mrfCommon/src/mrfFracSynth.h
@@ -52,6 +52,8 @@
 
 #include <epicsTypes.h>                 /* EPICS Architecture-independent type definitions        */
 
+#include <mrf/mrfCommonAPI.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,12 +62,15 @@ extern "C" {
 /*  Function Prototypes for Fractional Synthesizer Utility Routines                               */
 /**************************************************************************************************/
 
-epicsShareExtern epicsStatus   mrfSetEventClockSpeed (epicsFloat64,  epicsUInt32,  epicsFloat64,
+MRFCOMMON_API
+epicsStatus   mrfSetEventClockSpeed (epicsFloat64,  epicsUInt32,  epicsFloat64,
                                                       epicsFloat64*, epicsUInt32*, epicsInt32);
 
-epicsShareExtern epicsUInt32   FracSynthControlWord  (epicsFloat64, epicsFloat64, epicsInt32, epicsFloat64*);
+MRFCOMMON_API
+epicsUInt32   FracSynthControlWord  (epicsFloat64, epicsFloat64, epicsInt32, epicsFloat64*);
 
-epicsShareExtern epicsFloat64  FracSynthAnalyze      (epicsUInt32, epicsFloat64, epicsInt32);
+MRFCOMMON_API
+epicsFloat64  FracSynthAnalyze      (epicsUInt32, epicsFloat64, epicsInt32);
 
 /**************************************************************************************************/
 /*  Special Macros to Define Commonly Used Symbols                                                */

--- a/mrfCommon/src/object.cpp
+++ b/mrfCommon/src/object.cpp
@@ -48,10 +48,8 @@ alarm_exception::what() throw()
     return "Alarm!";
 }
 
-epicsShareFunc
 propertyBase::~propertyBase() {}
 
-epicsShareFunc
 void
 propertyBase::show(std::ostream& strm) const
 {

--- a/mrfCommon/src/objectTest.cpp
+++ b/mrfCommon/src/objectTest.cpp
@@ -6,8 +6,6 @@
 #include "testMain.h"
 
 #include "mrf/object.h"
-
-namespace {
 using namespace mrf;
 
 class mine : public ObjectInst<mine>
@@ -65,6 +63,7 @@ other::buildOne(const std::string& name, const std::string& klass, const Object:
     return new other(name);
 }
 
+namespace {
 
 void testMine()
 {

--- a/mrfCommon/src/objectTest.cpp
+++ b/mrfCommon/src/objectTest.cpp
@@ -10,6 +10,7 @@ using namespace mrf;
 
 class mine : public ObjectInst<mine>
 {
+    OBJECT_DECL(mine);
 public:
     int ival;
     double dval;
@@ -17,7 +18,9 @@ public:
     unsigned count;
 
     explicit mine(const std::string& n) : ObjectInst<mine>(n), ival(0), dval(0.0), count(0)
-    {}
+    {
+        OBJECT_INIT;
+    }
 
     /* no locking needed */
     virtual void lock() const{};
@@ -48,8 +51,12 @@ public:
 class other : public ObjectInst<other, mine>
 {
     typedef ObjectInst<other, mine> base_t;
+    OBJECT_DECL(other);
 public:
-    explicit other(const std::string& n) : base_t(n) {}
+    explicit other(const std::string& n) : base_t(n)
+    {
+        OBJECT_INIT;
+    }
     virtual ~other() {}
 
     int getX() const { return 42;}
@@ -94,14 +101,12 @@ void testMine()
 
     mrf::auto_ptr<property<int> > I2=o->getProperty<int>("I");
     testOk1(I2.get()!=NULL);
-    testOk1((*I)==(*I2));
 
     if(I2.get())
         testOk1(I2->get()==42);
 
     I2=o->getProperty<int>("val");
     testOk1(I2.get()!=NULL);
-    testOk1((*I)!=(*I2));
 
     if(I2.get())
         testOk1(I2->get()==42);
@@ -221,7 +226,7 @@ OBJECT_END(other)
 
 MAIN(objectTest)
 {
-    testPlan(39);
+    testPlan(37);
     testMine();
     testOther();
     testOther2();

--- a/mrfCommon/src/pollirq.cpp
+++ b/mrfCommon/src/pollirq.cpp
@@ -3,7 +3,6 @@
 #include <epicsEvent.h>
 #include <epicsMutex.h>
 #include <epicsGuard.h>
-#define epicsExportSharedSymbols
 #include "mrf/pollirq.h"
 
 IRQPoller::IRQPoller(pollerFN fn, void *arg, double period)

--- a/mrmShared/src/Makefile
+++ b/mrmShared/src/Makefile
@@ -2,9 +2,11 @@
 TOP=../..
 include $(TOP)/configure/CONFIG
 
+USR_CPPFLAGS += -DBUILDING_MRMSHARED_API
 USR_INCLUDES += -I$(TOP)/mrfCommon/src
 USR_INCLUDES += -I$(TOP)/evrMrmApp/src
 
+INC += mrmSharedAPI.h
 INC += mrmDataBufTx.h
 INC += mrmSeq.h
 INC += mrmpci.h

--- a/mrmShared/src/Makefile
+++ b/mrmShared/src/Makefile
@@ -27,6 +27,7 @@ mrmShared_SRCS += mrmspi.cpp
 
 mrmShared_LIBS += mrfCommon $(EPICS_BASE_IOC_LIBS)
 
+USR_SYS_LIBS_WIN32 += ws2_32
 #---------------------
 # Generic EPICS build rules
 #

--- a/mrmShared/src/mrmDataBufTx.h
+++ b/mrmShared/src/mrmDataBufTx.h
@@ -9,6 +9,7 @@
 #define MRMDATABUFTX_H_INC
 
 #include <epicsMutex.h>
+#include <mrmSharedAPI.h>
 
 #include "mrf/databuf.h"
 
@@ -16,7 +17,7 @@
  * With the MRM both the EVG and the EVR have
  * the exact same Tx control register
  */
-class epicsShareClass mrmDataBufTx : public dataBufTx
+class MRMSHARED_API mrmDataBufTx : public dataBufTx
 {
 public:
 

--- a/mrmShared/src/mrmSeq.cpp
+++ b/mrmShared/src/mrmSeq.cpp
@@ -134,6 +134,7 @@ struct SeqHW
 struct SoftSequence : public mrf::ObjectInst<SoftSequence>
 {
     typedef mrf::ObjectInst<SoftSequence> base_t;
+    OBJECT_DECL(SoftSequence);
 
     SoftSequence(SeqManager *o, const std::string& name);
     virtual ~SoftSequence();
@@ -400,6 +401,7 @@ SoftSequence::SoftSequence(SeqManager *o, const std::string& name)
     ,numEnd(0u)
     ,timeScale(0u) // raw/ticks
 {
+    OBJECT_INIT;
     scanIoInit(&changed);
     scanIoInit(&onStart);
     scanIoInit(&onEnd);
@@ -689,6 +691,8 @@ SeqManager::SeqManager(const std::string &name, Type t)
     :base_t(name)
     ,type(t)
 {
+    OBJECT_INIT;
+
     switch(type) {
     case TypeEVG:
     case TypeEVR:

--- a/mrmShared/src/mrmSeq.cpp
+++ b/mrmShared/src/mrmSeq.cpp
@@ -8,6 +8,7 @@
 #  include <rtems.h>
 #endif
 
+#include <algorithm>
 #include <stdio.h>
 
 #include <epicsMath.h>

--- a/mrmShared/src/mrmSeq.h
+++ b/mrmShared/src/mrmSeq.h
@@ -26,6 +26,7 @@ struct SoftSequence;
 class MRMSHARED_API SeqManager : public mrf::ObjectInst<SeqManager>
 {
     typedef mrf::ObjectInst<SeqManager> base_t;
+    OBJECT_DECL(SeqManager);
 public:
     // Which model card?
     // used handle external and software trigger source mapping

--- a/mrmShared/src/mrmSeq.h
+++ b/mrmShared/src/mrmSeq.h
@@ -11,7 +11,7 @@
 #include <string>
 
 #include <dbScan.h>
-#include <shareLib.h>
+#include <mrmSharedAPI.h>
 
 #include <mrf/object.h>
 
@@ -23,7 +23,7 @@
 struct SeqHW;
 struct SoftSequence;
 
-class epicsShareClass SeqManager : public mrf::ObjectInst<SeqManager>
+class MRMSHARED_API SeqManager : public mrf::ObjectInst<SeqManager>
 {
     typedef mrf::ObjectInst<SeqManager> base_t;
 public:
@@ -71,6 +71,6 @@ private:
     friend struct SoftSequence;
 };
 
-epicsShareExtern int SeqManagerDebug;
+MRMSHARED_API extern int SeqManagerDebug;
 
 #endif // MRMSEQ_H

--- a/mrmShared/src/mrmSharedAPI.h
+++ b/mrmShared/src/mrmSharedAPI.h
@@ -1,0 +1,46 @@
+#ifndef INC_mrmSharedAPI_h
+#define INC_mrmSharedAPI_h
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+/* Prior to 3.15, the signal for a DLL build was inverted */
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_MRMSHARED_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define MRMSHARED_API __declspec(dllexport)
+#  elif !defined(BUILDING_MRMSHARED_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define MRMSHARED_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define MRMSHARED_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(MRMSHARED_API)
+#  define MRMSHARED_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_mrmSharedAPI_h */

--- a/mrmShared/src/mrmspi.cpp
+++ b/mrmShared/src/mrmspi.cpp
@@ -14,7 +14,6 @@
 #include <epicsThread.h>
 
 #include <mrfCommonIO.h>
-#define epicsExportSharedSymbols
 #include "mrmspi.h"
 #include <epicsExport.h>
 

--- a/mrmShared/src/mrmspi.h
+++ b/mrmShared/src/mrmspi.h
@@ -14,10 +14,10 @@
 
 #include <mrfCommon.h>
 #include <mrf/spi.h>
-#include <shareLib.h>
+#include <mrmSharedAPI.h>
 
 // SPI bus access for 0x200 firmware series EVR and EVG cores.
-class epicsShareClass MRMSPI : public mrf::SPIInterface
+class MRMSHARED_API MRMSPI : public mrf::SPIInterface
 {
     volatile unsigned char * const base;
 public:

--- a/mrmShared/src/mrmtimesrc.h
+++ b/mrmShared/src/mrmtimesrc.h
@@ -8,12 +8,12 @@
 
 #include <string>
 
-#include <shareLib.h>
+#include <mrmSharedAPI.h>
 #include <epicsTypes.h>
 
 /* Handles sending shirt 0/1 events after the start of each second.
  */
-class epicsShareClass TimeStampSource
+class MRMSHARED_API TimeStampSource
 {
     struct Impl;
     Impl * const impl;

--- a/mrmShared/src/sfp.cpp
+++ b/mrmShared/src/sfp.cpp
@@ -34,6 +34,7 @@ SFP::SFP(const std::string &n, volatile unsigned char *reg)
     ,buffer(SFPMEM_SIZE)
     ,valid(false)
 {
+    OBJECT_INIT;
     updateNow();
 
     /* Check for SFP with LC connector */

--- a/mrmShared/src/sfp.h
+++ b/mrmShared/src/sfp.h
@@ -13,7 +13,9 @@
 
 #include <epicsMutex.h>
 
-class epicsShareClass SFP : public mrf::ObjectInst<SFP> {
+#include <mrmSharedAPI.h>
+
+class MRMSHARED_API SFP : public mrf::ObjectInst<SFP> {
     volatile unsigned char* base;
     typedef std::vector<epicsUInt8> buffer_t;
     buffer_t buffer;

--- a/mrmShared/src/sfp.h
+++ b/mrmShared/src/sfp.h
@@ -13,9 +13,12 @@
 
 #include <epicsMutex.h>
 
+#include <mrf/object.h>
+
 #include <mrmSharedAPI.h>
 
 class MRMSHARED_API SFP : public mrf::ObjectInst<SFP> {
+    OBJECT_DECL(SFP);
     volatile unsigned char* base;
     typedef std::vector<epicsUInt8> buffer_t;
     buffer_t buffer;


### PR DESCRIPTION
Many changes to permit building on Windows with mingw or msvc with static or dynamic linking.  The extensive changes are to replace usage of `sharedLib.h` with a set of `*_API` macros, and to rework the `class Object` tree to play well with dllimport/export.  There are also a number of smaller changes.

Builds and passes tests with `windows-x64` (cf. #41), but doesn't yet do anything useful (no hardware access).

@dirk-zimoch I think you can use this as a new starting point to try to make mrfioc2 do something useful on windows.
