### PR TITLE
minimal AER handling functionality

### DIFF
--- a/mrmShared/linux/mrf.h
+++ b/mrmShared/linux/mrf.h
@@ -25,6 +25,7 @@
 #ifdef CONFIG_PARPORT_NOT_PC
 #  include <linux/parport.h>
 #endif
+#include <linux/aer.h>
 
 
 /************************ Register definitions ****************************/

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -689,7 +689,11 @@ err_release:
 err_disable:
         pci_disable_device(dev);
 err_free:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
+        kzfree(priv);
+#else
         kfree_sensitive(priv);
+#endif
         return ret;
 }
 
@@ -816,7 +820,11 @@ mrf_remove(struct pci_dev *dev)
         pci_release_regions(dev);
         pci_disable_device(dev);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
+        kzfree(priv);
+#else
         kfree_sensitive(priv);
+#endif
 
         dev_info(&dev->dev, "MRF Cleaned up\n");
 }

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -687,7 +687,7 @@ err_release:
 err_disable:
         pci_disable_device(dev);
 err_free:
-        kzfree(priv);
+        kfree_sensitive(priv);
         return ret;
 }
 
@@ -814,7 +814,7 @@ mrf_remove(struct pci_dev *dev)
         pci_release_regions(dev);
         pci_disable_device(dev);
 
-        kzfree(priv);
+        kfree_sensitive(priv);
 
         dev_info(&dev->dev, "MRF Cleaned up\n");
 }

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -912,11 +912,6 @@ static
 void
 mrf_error_resume(struct pci_dev *dev) {
     /* FIXME: Anything else to do here? */
-#if KERNEL_VERSION(5,7,0) <= LINUX_VERSION_CODE
-	pci_aer_clear_nonfatal_status(dev);
-#else
-	pci_cleanup_aer_uncorrect_error_status(dev);
-#endif
 }
 
 static const struct pci_error_handlers mrf_err_handler = {

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -879,7 +879,11 @@ static
 void
 mrf_error_resume(struct pci_dev *dev) {
     /* FIXME: Anything else to do here? */
-    pci_aer_clear_nonfatal_status(dev);
+#if KERNEL_VERSION(5,7,0) <= LINUX_VERSION_CODE
+	pci_aer_clear_nonfatal_status(dev);
+#else
+	pci_cleanup_aer_uncorrect_error_status(dev);
+#endif
 }
 
 static const struct pci_error_handlers mrf_err_handler = {

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -857,7 +857,7 @@ pci_ers_result_t
 mrf_slot_reset(struct pci_dev *dev)
 {
 	if (pci_enable_device(dev)) {
-		pci_err(dev, "failed to re-enable after slot reset\n");
+		dev_err(&dev->dev, "failed to re-enable after slot reset\n");
 		return PCI_ERS_RESULT_DISCONNECT;
 	}
 


### PR DESCRIPTION
As per #44, this is a PR that introduces `struct pci_error_handlers` and its rudimentary callbacks that result in AER process to successfully restore the PCI register space of a mTCA MRF EVR after a bus reset was issued due to detection of a PCIe error.

Without handling the AER the PCI device makes the recovery process fail, even if all the other device on path to recovery can handle AER.

I do not have sufficient knowledge of the internals of the MRF kernel driver and its interaction with the card/firmware hence the `mrf_error_detected()` and `mrf_slot_reset()` might need to do a bit more than just disabling/enabling the PCI device.

This code was tested with the https://git.kernel.org/pub/scm/linux/kernel/git/gong.chen/aer-inject.git on a mTCA form factor of EVR (mTCA-EVR-300).