### PR TITLE
add PS trigger functionality to pulse generators

### DIFF
--- a/evrApp/Db/evrpulser.db
+++ b/evrApp/Db/evrpulser.db
@@ -165,3 +165,24 @@ record(waveform, "$(PN)Label-I") {
   field(NELM, "128")
   info(autosaveFields_pass1, "VAL")
 }
+
+# Triger pulser generator by one or more prescalers
+record(mbboDirect, "$(PN)PSTrig-Sel")
+{
+  field(DTYP, "Obj Prop uint32")
+  field(OUT , "@OBJ=$(OBJ), PROP=PSTrig")
+  field(PINI, "YES")
+  field(NOBT, "8")
+  field(VAL , "0")
+  field(FLNK, "$(PN)PSTrig-RB")
+  info(autosaveFields_pass0, "RVAL")
+}
+
+record(mbbiDirect, "$(PN)PSTrig-RB")
+{
+  field(DTYP, "Obj Prop uint32")
+  field(INP , "@OBJ=$(OBJ), PROP=PSTrig")
+  field(PINI, "YES")
+  field(NOBT, "8")
+  info(autosaveFields_pass0, "RVAL")
+}

--- a/evrApp/src/evr.cpp
+++ b/evrApp/src/evr.cpp
@@ -185,6 +185,8 @@ OBJECT_BEGIN(Pulser) {
 
     OBJECT_PROP2("Prescaler", &Pulser::prescaler, &Pulser::setPrescaler);
 
+    OBJECT_PROP2("PSTrig", &Pulser::psTrig, &Pulser::setPSTrig);
+
 } OBJECT_END(Pulser)
 
 

--- a/evrApp/src/evr/pulser.h
+++ b/evrApp/src/evr/pulser.h
@@ -77,6 +77,13 @@ public:
   virtual void setPrescaler(epicsUInt32)=0;
   /*@}*/
 
+  /**\defgroup scaler Set prescaler triggering
+   */
+  /*@{*/
+  virtual epicsUInt32 psTrig() const=0;
+  virtual void setPSTrig(epicsUInt32)=0;
+  /*@}*/
+
   /**\defgroup pol Set output polarity
    *
    * Selects normal or inverted.

--- a/evrFRIBApp/src/evr_frib.h
+++ b/evrFRIBApp/src/evr_frib.h
@@ -74,6 +74,9 @@ struct PulserFRIB : public Pulser
     virtual epicsUInt32 prescaler() const { return 1u; }
     virtual void setPrescaler(epicsUInt32) {}
 
+    virtual epicsUInt32 psTrig() const { return 0u; }
+    virtual void setPSTrig(epicsUInt32) {}
+
     virtual bool polarityInvert() const { return false; }
     virtual void setPolarityInvert(bool) {}
 

--- a/evrMrmApp/src/drvemPulser.cpp
+++ b/evrMrmApp/src/drvemPulser.cpp
@@ -138,6 +138,33 @@ MRMPulser::setPrescaler(epicsUInt32 v)
     WRITE32(owner.base, PulserScal(id), v);
 }
 
+epicsUInt32
+MRMPulser::psTrig() const
+{
+    epicsUInt32 r = 0;
+    for (int i = 0; i < ScalerMax; i++) {
+        if (READ32(owner.base, ScalerPulsTrig(i)) & (1 << id)) {
+            r |= 1 << i;
+        }
+    }
+
+    return r;
+}
+
+void
+MRMPulser::setPSTrig(epicsUInt32 v)
+{
+    for (int i = 0; i < ScalerMax; i++) {
+        epicsUInt32 t = READ32(owner.base, ScalerPulsTrig(i));
+        if (v & (1 << i)) {
+            t |= 1 << id;
+        } else {
+            t &= ~(1 << id);
+        }
+        WRITE32(owner.base, ScalerPulsTrig(i), t);
+    }
+}
+
 bool
 MRMPulser::polarityInvert() const
 {

--- a/evrMrmApp/src/drvemPulser.h
+++ b/evrMrmApp/src/drvemPulser.h
@@ -46,6 +46,9 @@ public:
     virtual epicsUInt32 prescaler() const OVERRIDE FINAL;
     virtual void setPrescaler(epicsUInt32) OVERRIDE FINAL;
 
+    virtual epicsUInt32 psTrig() const OVERRIDE FINAL;
+    virtual void setPSTrig(epicsUInt32) OVERRIDE FINAL;
+
     virtual bool polarityInvert() const OVERRIDE FINAL;
     virtual void setPolarityInvert(bool) OVERRIDE FINAL;
 

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -187,10 +187,11 @@
 
 
 #define U32_ScalerN     0x100
-#  define ScalerMax 3
-/* 0 <= N <= 2 */
+#  define ScalerMax 8
+/* 0 <= N <= 7 */
 #define U32_Scaler(N)   (U32_ScalerN + (4*(N)))
 #  define ScalerPhasOffs_offset 0x20
+#define U32_ScalerPulsTrig(N) (U32_ScalerN + 0x40 + (4*(N)))
 
 #define U32_PulserNCtrl 0x200
 #define U32_PulserNScal 0x204


### PR DESCRIPTION
Multiple prescalers can trigger the same pulse generator. This can be
used along with prescaler shifting to create more complicated signals.

e.g. setting:
dbpf MRF:{EVR1-DlyGen:4}PSTrig-Sel.B0 1
dbpf MRF:{EVR1-DlyGen:4}PSTrig-Sel.B4 1

will result in pulse generator 4 to be triggered by prescalers' 0 & 4
rising edge