### PR TITLE
Fix RFDIV macro

### DIFF
--- a/evgMrmApp/Db/cpci-evg-300.substitutions
+++ b/evgMrmApp/Db/cpci-evg-300.substitutions
@@ -16,7 +16,7 @@ pattern { P, OBJ, EVG, dbusBit }
 }
 
 file evgEvtClk.db {
-{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", RFDIV="\$(RFDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 file evgInput.db {

--- a/evgMrmApp/Db/mtca-evm-300.substitutions
+++ b/evgMrmApp/Db/mtca-evm-300.substitutions
@@ -20,7 +20,7 @@ pattern { P, OBJ, EVG, dbusBit }
 }
 
 file evgEvtClk.db {
-{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", RFDIV="\$(RFDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 file evgInput.db {

--- a/evgMrmApp/Db/vme-evg230-nsls2.substitutions
+++ b/evgMrmApp/Db/vme-evg230-nsls2.substitutions
@@ -16,7 +16,7 @@ pattern { P, OBJ, EVG, dbusBit }
 }
 
 file evgEvtClk.db {
-{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", RFDIV="\$(RFDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 file evgInput.db {

--- a/evgMrmApp/Db/vme-evg230.substitutions
+++ b/evgMrmApp/Db/vme-evg230.substitutions
@@ -16,7 +16,7 @@ pattern { P, OBJ, EVG, dbusBit }
 }
 
 file evgEvtClk.db {
-{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS){$(D)-EvtClk}", OBJ="$(EVG)", FRF="\$(FRF=499.68)", RFDIV="\$(RFDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 file evgInput.db {


### PR DESCRIPTION
evgEvtClk.db uses a RFIDV macro instead of FDIV.