### PR TITLE
fix: Better handling of the clocks for EVR widths and delays. 

### DIFF
--- a/evrMrmApp/src/drvemPulser.cpp
+++ b/evrMrmApp/src/drvemPulser.cpp
@@ -67,7 +67,7 @@ MRMPulser::setDelay(double v)
 {
     double scal=double(prescaler());
     if (scal<=0) scal=1;
-    double clk=owner.clockTS();
+    double clk = (owner.clock() == 0.0) ? owner.clockTS() : owner.clock(); // in MHz. MTicks/second
 
     epicsUInt32 ticks=roundToUInt((v*clk)/scal);
 
@@ -85,7 +85,7 @@ MRMPulser::delay() const
 {
     double scal=double(prescaler());
     double ticks=double(delayRaw());
-    double clk=owner.clockTS();
+    double clk = (owner.clock() == 0.0) ? owner.clockTS() : owner.clock(); // in MHz. MTicks/second
     if (scal<=0) scal=1;
 
     return (ticks*scal)/clk;
@@ -101,7 +101,7 @@ void
 MRMPulser::setWidth(double v)
 {
     double scal=double(prescaler());
-    double clk=owner.clockTS();
+    double clk = (owner.clock() == 0.0) ? owner.clockTS() : owner.clock(); // in MHz. MTicks/second
     if (scal<=0) scal=1;
 
     epicsUInt32 ticks=roundToUInt((v*clk)/scal);
@@ -120,7 +120,7 @@ MRMPulser::width() const
 {
     double scal=double(prescaler());
     double ticks=double(widthRaw());
-    double clk=owner.clockTS();
+    double clk = (owner.clock() == 0.0) ? owner.clockTS() : owner.clock(); // in MHz. MTicks/second
     if (scal<=0) scal=1;
 
     return (ticks*scal)/clk;

--- a/evrMrmApp/src/drvemPulser.cpp
+++ b/evrMrmApp/src/drvemPulser.cpp
@@ -67,7 +67,7 @@ MRMPulser::setDelay(double v)
 {
     double scal=double(prescaler());
     if (scal<=0) scal=1;
-    double clk=owner.clock(); // in MHz.  MTicks/second
+    double clk=owner.clockTS();
 
     epicsUInt32 ticks=roundToUInt((v*clk)/scal);
 
@@ -85,7 +85,7 @@ MRMPulser::delay() const
 {
     double scal=double(prescaler());
     double ticks=double(delayRaw());
-    double clk=owner.clock(); // in MHz.  MTicks/second
+    double clk=owner.clockTS();
     if (scal<=0) scal=1;
 
     return (ticks*scal)/clk;
@@ -101,7 +101,7 @@ void
 MRMPulser::setWidth(double v)
 {
     double scal=double(prescaler());
-    double clk=owner.clock(); // in MHz.  MTicks/second
+    double clk=owner.clockTS();
     if (scal<=0) scal=1;
 
     epicsUInt32 ticks=roundToUInt((v*clk)/scal);
@@ -120,7 +120,7 @@ MRMPulser::width() const
 {
     double scal=double(prescaler());
     double ticks=double(widthRaw());
-    double clk=owner.clock(); // in MHz.  MTicks/second
+    double clk=owner.clockTS();
     if (scal<=0) scal=1;
 
     return (ticks*scal)/clk;


### PR DESCRIPTION
EVM EVRU and EVRD clock registry is empty, it means it is needed a mechanism to resolve it.