### PR TITLE
fix: Normalize the Time-I record timestamp to 1s.

### DIFF
--- a/evrApp/src/devEvrStringIO.cpp
+++ b/evrApp/src/devEvrStringIO.cpp
@@ -101,10 +101,18 @@ try {
     if (ts.secPastEpoch==priv->last_bad)
         return 0;
 
+    // Normalize the timestamp to seconds
+    epicsTimeStamp ts_sec = ts;
+    // Round the timestamp to 1s accuracy
+    if (ts_sec.nsec + 500000000u >= 1000000000u)
+        ts_sec.secPastEpoch += 1;
+
+    ts_sec.nsec = 0; // Remove the ns part
+
     size_t r=epicsTimeToStrftime(prec->val,
                                  sizeof(prec->val),
                                  "%a, %d %b %Y %H:%M:%S %z",
-                                 &ts);
+                                 &ts_sec);
     if(r==0||r==sizeof(prec->val)){
         recGblRecordError(S_dev_badArgument, (void*)prec,
                           "Format string resulted in error");

--- a/mrfCommon/src/mrfCommon.h
+++ b/mrfCommon/src/mrfCommon.h
@@ -252,7 +252,7 @@ struct SB {
  *
  * To quote the manual:
  *   Subrelease ID For production releases the subrelease ID counts up from 00.
- *   For pre-releases this ID is used “backwards” counting down from ff i.e. when
+ *   For pre-releases this ID is used "backwards" counting down from ff i.e. when
  *   approacing release 12000207, we have prereleases 12FF0206, 12FE0206,
  *   12FD0206 etc. in this order.
  */


### PR DESCRIPTION
Time-I displays the time without the ms part which means it has to be rounded accordingly.