### PR TITLE
Changing minor FW version variable to unsigned

### DIFF
--- a/mrfCommon/src/mrfCommon.cpp
+++ b/mrfCommon/src/mrfCommon.cpp
@@ -35,8 +35,7 @@ std::ostream& operator<<(std::ostream& strm, const MRFVersion& ver)
     strm<<std::hex<<ver.firmware()
         <<std::hex<<std::setfill('0')<<std::setw(2)<<ver.revision()
         <<'.'
-        <<((ver.subrelease()<0) ? "-" : "")
-        <<abs(ver.subrelease());
+        <<ver.subrelease();
     return strm;
 }
 

--- a/mrfCommon/src/mrfCommon.h
+++ b/mrfCommon/src/mrfCommon.h
@@ -259,7 +259,7 @@ struct SB {
 class epicsShareClass MRFVersion
 {
     const epicsUInt16 m_major;
-    const epicsInt8 m_minor;
+    const epicsUInt8 m_minor;
 public:
 
     explicit MRFVersion(epicsUInt32 regval)
@@ -271,7 +271,7 @@ public:
 
     inline unsigned firmware() const { return m_major>>8; }
     inline unsigned revision() const { return m_major&0xff; }
-    inline int subrelease() const { return m_minor; }
+    inline unsigned subrelease() const { return m_minor; }
 
     int compare(const MRFVersion& o) const;
     inline bool operator>(const MRFVersion& o) const { return compare(o)==1; }


### PR DESCRIPTION
To allow for more than 128 versions of FW minor releases, the `m_minor` variable type is changed from `epicsInt8` to `epicsUInt8`.