### PR TITLE
Changes for UTAG compatibility with base 7.0.5 and earlier

### DIFF
--- a/evrApp/src/devEvrEvent.cpp
+++ b/evrApp/src/devEvrEvent.cpp
@@ -284,7 +284,6 @@ epicsExportAddress(dset,devEVEventEVR);
 
 }
 
-
 /*
  * Timestamping with UTAG extension
  * Date:    5.12.2023
@@ -292,14 +291,15 @@ epicsExportAddress(dset,devEVEventEVR);
  *          Jerzy Jamroz <jerzy.jamroz@gmail.com>
  */
 
-#ifdef DBR_UTAG
+#if EPICS_VERSION >= 7
 
 #include <int64outRecord.h>
 
 static long process_int64out(int64outRecord *prec)
 {
-    priv *p = static_cast<priv *>(prec->dpvt);
     long ret = 0;
+#ifdef DBR_UTAG
+    priv *p = static_cast<priv *>(prec->dpvt);
     try
     {
 
@@ -325,6 +325,10 @@ static long process_int64out(int64outRecord *prec)
         recGblRecordError(S_db_noMemory, (void *)prec, e.what());
         ret = S_db_noMemory;
     }
+#else
+    recGblRecordError(S_db_noSupport, (void *)prec, "UTAG not supported in EPCIS base prior to 7.0.6");
+    ret = S_db_noSupport;
+#endif
     return ret;
 }
 


### PR DESCRIPTION
While trying to build `master` branch  at commit d6cdcbf0798e18b08bbf608e6cd5d9be68b6cf59 with EPICS base `7.0.5` I got the following error:

```
/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE         -DUSE_TYPED_RSET   -D_X86_64_  -DUNIX  -Dlinux      -O3 -g   -Wall      -mtune=generic      -m64  -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include   -I/opt/epics7/modules/devlib2/include -I/opt/epics7/base/include/compiler/gcc -I/opt/epics7/base/include/os/Linux -I/opt/epics7/base/include     -I../../../mrfCommon/src    -c ../evrMain.cpp
/usr/bin/g++  -D_GNU_SOURCE -D_DEFAULT_SOURCE         -DUSE_TYPED_RSET   -D_X86_64_  -DUNIX  -Dlinux      -O3 -g   -Wall      -mtune=generic      -m64  -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/Linux -I../../../include   -I/opt/epics7/modules/devlib2/include -I/opt/epics7/base/include/compiler/gcc -I/opt/epics7/base/include/os/Linux -I/opt/epics7/base/include     -I../../../mrfCommon/src    -c evrtest_registerRecordDeviceDriver.cpp
/usr/bin/g++ -o evrtest  -L/home/zoven/workspace/mrfioc2/lib/linux-x86_64 -L/opt/epics7/base-7.0.5/lib/linux-x86_64 -Wl,-rpath,/home/zoven/workspace/mrfioc2/lib/linux-x86_64 -Wl,-rpath,/opt/epics7/base-7.0.5/lib/linux-x86_64           -rdynamic -m64         evrMain.o evrtest_registerRecordDeviceDriver.o    -levr -lmrfCommon -ldbRecStd -ldbCore -lca -lCom
evrtest_registerRecordDeviceDriver.o: In function `__static_initialization_and_destruction_0':
/home/zoven/workspace/mrfioc2/evrApp/src/O.linux-x86_64/evrtest_registerRecordDeviceDriver.cpp:195: undefined reference to `pvar_dset_devI64OEventUtagEVR'
collect2: error: ld returned 1 exit status
make[3]: *** [evrtest] Error 1
make[3]: Leaving directory `/home/zoven/workspace/mrfioc2/evrApp/src/O.linux-x86_64'
make[2]: *** [install.linux-x86_64] Error 2
make[2]: Leaving directory `/home/zoven/workspace/mrfioc2/evrApp/src'
make[1]: *** [src.install] Error 2
make[1]: Leaving directory `/home/zoven/workspace/mrfioc2/evrApp'
make: *** [evrApp.install] Error 2
```

Tracing the error source pointed to the commit: 277abf2216a5f977d76ba119a19be6760a84c362

The issue is that the `Makefile` depends on the version of the EPICS base 7.0 and the `DBR_UTAG` has been added in base `7.0.6`

Proposed changes provide compatibility with earlier versions of the EPICS base.


