### PR TITLE
fix: EVRU/D use the irqpoller until the isr is implemented.

### DIFF
--- a/evgMrmApp/src/Makefile
+++ b/evgMrmApp/src/Makefile
@@ -23,7 +23,7 @@ LIBRARY_IOC += evgmrm
 # INC += evgOutput.h
 # INC += mrmevgseq.h
 
-SRC_DIRS += ../devSupport 
+SRC_DIRS += ../devSupport
 
 #All the source files that are compiled and put in the library.
 evgmrm_SRCS += evgInit.cpp

--- a/evgMrmApp/src/evgInit.cpp
+++ b/evgMrmApp/src/evgInit.cpp
@@ -133,7 +133,7 @@ evgShutdown(void*)
     mrf::Object::visitObjects(&disableIRQ,0);
 }
 
-static void 
+static void
 inithooks(initHookState state) {
     epicsUInt8 lvl;
     switch(state) {
@@ -225,7 +225,7 @@ mrmEvgSetupVME (
         printf("##### Setting up MRF EVG in VME Slot %d #####\n",slot);
         printf("Found Vendor: %08x\nBoard: %08x\nRevision: %08x\n",
                info.vendor, info.board, info.revision);
-        
+
         epicsUInt32 xxx = CSRRead32(csrCpuAddr + CSR_FN_ADER(1));
         if(xxx)
             printf("Warning: EVG not in power on state! (%08x)\n", xxx);
@@ -536,6 +536,8 @@ mrmEvgSetupPCI (
             delete evg;
             return -1;
         } else {
+            new IRQPoller(&EVRMRM::isr_poll, static_cast<void*>(evg->getEvruMrm()), 0.1);
+            new IRQPoller(&EVRMRM::isr_poll, static_cast<void*>(evg->getEvrdMrm()), 0.1);
             printf("PCI interrupt connected!\n");
         }
 
@@ -562,7 +564,7 @@ static const iocshArg * const mrmEvgSetupVMEArgs[5] = { &mrmEvgSetupVMEArg0,
 static const iocshFuncDef mrmEvgSetupVMEFuncDef = { "mrmEvgSetupVME", 5,
                                                     mrmEvgSetupVMEArgs };
 
-static void 
+static void
 mrmEvgSetupVMECallFunc(const iocshArgBuf *args) {
     mrmEvgSetupVME(args[0].sval,
             args[1].ival,
@@ -750,7 +752,7 @@ reportCard(mrf::Object* obj, void* arg) {
     }
 
     evg->show(*level);
-    
+
     if(*level >= 2)
         printregisters(evg->getRegAddr());
 
@@ -758,7 +760,7 @@ reportCard(mrf::Object* obj, void* arg) {
     return true;
 }
 
-static long 
+static long
 report(int level) {
     printf("===  Begin MRF EVG support   ===\n");
     mrf::Object::visitObjects(&reportCard, (void*)&level);

--- a/evgMrmApp/src/evgMrm.h
+++ b/evgMrmApp/src/evgMrm.h
@@ -41,9 +41,9 @@
 #include "drvem.h"
 
 /*********
- * Each EVG will be represented by the instance of class 'evgMrm'. Each evg 
+ * Each EVG will be represented by the instance of class 'evgMrm'. Each evg
  * object maintains a list to all the evg sub-componets i.e. Event clock,
- * Software Events, Trigger Events, Distributed bus, Multiplex Counters, 
+ * Software Events, Trigger Events, Distributed bus, Multiplex Counters,
  * Input, Output etc.
  */
 class wdTimer;
@@ -198,6 +198,9 @@ private:
     // EVM only
     mrf::auto_ptr<FCT> fct;
     mrf::auto_ptr<EVRMRM> evru, evrd;
+public:
+    EVRMRM* getEvruMrm() const { return evru.get(); } // EVRU MRM accessor
+    EVRMRM* getEvrdMrm() const { return evrd.get(); } // EVRD MRM accessor
 };
 
 #endif //EVG_MRM_H

--- a/evrApp/Db/evrevent.db
+++ b/evrApp/Db/evrevent.db
@@ -24,5 +24,5 @@ record(calc, "$(EN)Cnt-I") {
   field(DISV, "0")
   field(CALC, "A+1")
   field(INPA, "$(EN)Cnt-I NPP")
-  field(TSEL, "$(EN)-SP.TIME")
+  $(SFTSEN=)field(TSEL, "$(EN)-SP.TIME")
 }

--- a/evrApp/Db/evreventutag.db
+++ b/evrApp/Db/evreventutag.db
@@ -23,5 +23,5 @@ record(calc, "$(EN)Cnt-I") {
   #field(DISV, "0")
   field(CALC, "A+1")
   field(INPA, "$(EN)Cnt-I NPP")
-  field(TSEL, "$(EN)-SP.TIME")
+  $(SFTSEN=)field(TSEL, "$(EN)-SP.TIME")
 }

--- a/mrfCommon/src/Makefile
+++ b/mrfCommon/src/Makefile
@@ -73,7 +73,7 @@ mrfCommon_SRCS += mrfCommon.cpp
 mrfCommon_SRCS += spi.cpp
 mrfCommon_SRCS += flash.cpp
 mrfCommon_SRCS += flashiocsh.cpp
-#NOTINUSE: mrfCommon_SRCS += pollirq.cpp
+mrfCommon_SRCS += pollirq.cpp #MTCA EVM EVRU/D usage
 
 mrfCommon_LIBS += $(EPICS_BASE_IOC_LIBS)
 


### PR DESCRIPTION
- Until EVM-EVRU/D interrupts are implemented in the EVM, the irqpoller will be delivering the capability.
- SFTSEN macro allows to use of the software timestamp.