### PR TITLE
fix: Correct the setFrequency command

### DIFF
--- a/evgMrmApp/src/evgMxc.cpp
+++ b/evgMrmApp/src/evgMxc.cpp
@@ -63,8 +63,8 @@ evgMxc::getPrescaler() const {
 
 void
 evgMxc::setFrequency(epicsFloat64 freq) {
-    epicsUInt32 clkSpeed = (epicsUInt32)(getFrequency() *
-                            pow(10.0, 6));
+    epicsUInt32 clkSpeed = (epicsFloat64)m_owner->getFrequency()
+                             * pow(10.0, 6);
     epicsUInt32 preScaler = (epicsUInt32)((epicsFloat64)clkSpeed / freq);
     
     setPrescaler(preScaler);


### PR DESCRIPTION
The setFrequency command doesn't set the correct prescaler and so the frequency, because the prescaler is wrongly computed. 

We need to use the  `m_owner->GetFrequency` and not `getFrequency()`, otherwise we obtain a frequency that is not correct and change according to the prescaler computed.

![image](https://github.com/epics-modules/mrfioc2/assets/25428659/84c75089-864b-4929-9587-b92cfe348e8b)

It seems you are using git cliff, so I've tried to use a correct commit message, tell me if its ok otherwise I can change it.