### PR TITLE
Complete MTCA EVR300U substitution file 

### DIFF
--- a/evrMrmApp/Db/evr-mtca-300u.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.substitutions
@@ -284,6 +284,133 @@ file "evrpulsermap.db"
 {31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
 {31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
 {31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+
+
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+# gate generators mappings
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Set2-SP", "$(EVR):Pul$(PID)", Set, 0}
+
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+# gate generators mappings
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)\$(dsh=-)DlyGen\$(s=:)$(PID)\$(ES)Evt\$(s=:)Reset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+
+
 }
 
 # pulser masking controls
@@ -313,6 +440,19 @@ file "evrin.db"
 {IN, OBJ, DESC}
 {"\$(P)\$(dsh=-)In\$(s=:)0\$(ES)", "$(EVR):FPIn0", "IN0 (TTL)"}
 {"\$(P)\$(dsh=-)In\$(s=:)1\$(ES)", "$(EVR):FPIn1", "IN1 (TTL)"}
+{"\$(P)\$(dsh=-)UnivIn\$(s=:)0\$(ES)", "$(EVR):FPIn4", "UnivIN0"}
+{"\$(P)\$(dsh=-)UnivIn\$(s=:)1\$(ES)", "$(EVR):FPIn5", "UnivIN1"}
+{"\$(P)\$(dsh=-)UnivIn\$(s=:)2\$(ES)", "$(EVR):FPIn6", "UnivIN2"}
+{"\$(P)\$(dsh=-)UnivIn\$(s=:)3\$(ES)", "$(EVR):FPIn7", "UnivIN3"}
+
+{"\$(P)\$(dsh=-)BPIn\$(s=:)0\$(ES)", "$(EVR):FPIn24", "BPIN0 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)1\$(ES)", "$(EVR):FPIn25", "BPIN1 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)2\$(ES)", "$(EVR):FPIn26", "BPIN2 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)3\$(ES)", "$(EVR):FPIn27", "BPIN3 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)4\$(ES)", "$(EVR):FPIn28", "BPIN4 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)5\$(ES)", "$(EVR):FPIn29", "BPIN5 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)6\$(ES)", "$(EVR):FPIn30", "BPIN6 (LVDS)"}
+{"\$(P)\$(dsh=-)BPIn\$(s=:)7\$(ES)", "$(EVR):FPIn31", "BPIN7 (LVDS)"}
 }
 
 file "mrmevrdlymodule.template"
@@ -320,6 +460,7 @@ file "mrmevrdlymodule.template"
 {SLOT, P, OBJ}
 {0, "\$(P)\$(dsh=-)Out\$(s=:)FPDly$(SLOT)\$(ES)", "$(EVR)"}
 {1, "\$(P)\$(dsh=-)Out\$(s=:)FPDly$(SLOT)\$(ES)", "$(EVR)"}
+
 }
 
 

--- a/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
@@ -221,6 +221,132 @@ file "evrpulsermap.db"
 {31,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
 {31,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
 {31,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+
+
 }
 
 # pulser masking controls
@@ -248,6 +374,19 @@ file "evrdcpulser.template"
 file "evrin.db"
 {pattern
 {IN, OBJ, DESC}
-{"\$(P)In0", "$(EVR):FPIn0", "IN0 (TTL)"}
-{"\$(P)In1", "$(EVR):FPIn1", "IN1 (TTL)"}
+{"\$(P)In0"     , "$(EVR):FPIn0" , "IN0 (TTL)"}
+{"\$(P)In1"     , "$(EVR):FPIn1" , "IN1 (TTL)"}
+{"\$(P)UnivIn0" , "$(EVR):FPIn4" , "UnivIN0"}
+{"\$(P)UnivIn1" , "$(EVR):FPIn5" , "UnivIN1"}
+{"\$(P)UnivIn2" , "$(EVR):FPIn6" , "UnivIN2"}
+{"\$(P)UnivIn3" , "$(EVR):FPIn7" , "UnivIN3"}
+{"\$(P)BPIn0"   , "$(EVR):FPIn24", "BPIN0 (LVDS)"}
+{"\$(P)BPIn1"   , "$(EVR):FPIn25", "BPIN1 (LVDS)"}
+{"\$(P)BPIn2"   , "$(EVR):FPIn26", "BPIN2 (LVDS)"}
+{"\$(P)BPIn3"   , "$(EVR):FPIn27", "BPIN3 (LVDS)"}
+{"\$(P)BPIn4"   , "$(EVR):FPIn28", "BPIN4 (LVDS)"}
+{"\$(P)BPIn5"   , "$(EVR):FPIn29", "BPIN5 (LVDS)"}
+{"\$(P)BPIn6"   , "$(EVR):FPIn30", "BPIN6 (LVDS)"}
+{"\$(P)BPIn7"   , "$(EVR):FPIn31", "BPIN7 (LVDS)"}
 }
+


### PR DESCRIPTION
It adds function set and reset, planned in the substitutions files. 
It also adds missing inputs : The four possible universal inputs and the 8 backplane inputs.

This version has been tested in labo and another version of mrfioc2 with similar modifications has been used in production since 3 years.