### PR TITLE
Update documentation to remove reference to source forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What is Available?
 
 * More infomation on the Micro Research hardware can be found on their website http://www.mrf.fi/.
 
-* Documentation at [http://epics.sourceforge.net/mrfioc2](http://epics.sourceforge.net/mrfioc2)
+* Documentation at [https://epics-modules.github.io/mrfioc2](https://epics-modules.github.io/mrfioc2)
 
 Prerequisites
 -------------

--- a/documentation/mainpage.h
+++ b/documentation/mainpage.h
@@ -16,7 +16,7 @@ event timing systems.
 
 @section whereis Source
 
-Releases can be found at @url http://sourceforge.net/projects/epics/files/mrfioc2/
+Releases can be found at @url https://github.com/epics-modules/mrfioc2/releases
 
 This module is versioned with Git and can be viewed at
 @url https://github.com/epics-modules/mrfioc2/
@@ -25,7 +25,7 @@ Or checked out with
 
 git clone https://github.com/epics-modules/mrfioc2.git
 
-The canonical version of this page is @url http://epics.sourceforge.net/mrfioc2/
+The canonical version of this page is @url http://epics-modules.github.io/mrfioc2
 
 @subsection requires Requires
 
@@ -39,7 +39,7 @@ MSI (Macro expansion tool)  Required with Base < 3.15.1
 
 devLib2 >= 2.9
 
-@url http://epics.sourceforge.net/devlib2/
+@url https://epics-modules.github.io/devlib2/
 
 RTEMS >= 4.9.x, vxWorks >=6.7, or Linux >= 2.6.26.
 

--- a/scripts/pushdoc.sh
+++ b/scripts/pushdoc.sh
@@ -13,10 +13,16 @@ die() {
 builddoc() {
   doxygen
   lyx -batch -e pdf evr-usage.lyx
-  lyx -batch -e pdf evg-usage.lyx
+  lyx -batch -e pdflatex evg-usage.lyx
+  pdflatex evg-usage
   mv evg-usage.pdf evr-usage.pdf html/
 }
 
 (cd documentation && builddoc)
 
-rsync -av --delete "$@" documentation/html/ $USER,epics@frs.sourceforge.net:/home/project-web/epics/htdocs/mrfioc2/
+git checkout gh-pages
+cp -r documentation/html/* .
+rm -rf documentation
+git add .
+git commit -m "Last updates to documentation"
+git push origin gh-pages


### PR DESCRIPTION
Update documentation and README.md to remove reference to source forge and point to github pages.
Also updated pushdoc script to be compatible with githubpages 