### PR TITLE
build: Include action to release deb and rpm dkms packages

### DIFF
--- a/.github/workflows/release-dkms-deb-package.yml
+++ b/.github/workflows/release-dkms-deb-package.yml
@@ -1,0 +1,33 @@
+name: Create and release kernel module deb package
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+        - 'kmod*d*'
+
+jobs:
+  Create_Packages:
+    name: Create Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: "apt-get install"
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install dkms debhelper
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: "REPO"
+
+      - name: Build packages
+        run: |
+            cd REPO/mrmShared/linux
+            dpkg-buildpackage
+      - name: Release the Package
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+              REPO/mrmShared/*.deb

--- a/.github/workflows/release-dkms-rpm-package.yml
+++ b/.github/workflows/release-dkms-rpm-package.yml
@@ -1,0 +1,28 @@
+name: Create and release kernel module rpm package
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+        - 'kmod*r*'
+
+jobs:
+  Create_Packages:
+    name: Create Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: "REPO"
+
+      - name: Build packages
+        run: |
+            cd REPO/mrmShared/linux/dkms-rpm
+            make
+      - name: Release the Package
+        uses: softprops/action-gh-release@v1
+        with:
+          files: REPO/mrmShared/linux/dkms-rpm/rpmbuild/RPMS/*/*.rpm

--- a/mrmShared/linux/debian/rules
+++ b/mrmShared/linux/debian/rules
@@ -26,3 +26,5 @@ override_dh_auto_install:
 override_dh_auto_clean:
 override_dh_installudev:
 	dh_installudev --priority=50
+override_dh_builddeb:
+	    dh_builddeb -- -Zgzip

--- a/mrmShared/linux/dkms-rpm/mrf.spec.in
+++ b/mrmShared/linux/dkms-rpm/mrf.spec.in
@@ -13,8 +13,7 @@ Vendor: EPICS Community
 License: GPLv2
 Group: System Environment/Kernel
 URL: https://github.com/epics-modules/mrfioc2
-BuildRequires: autoconf libtool gcc gcc-c++
-BuildArch: @@ARCH@@
+BuildArch: noarch
 Requires: dkms
 Requires: udev
 BuildRoot: %{_tmppath}/%{kmod_name}-%{version}-root


### PR DESCRIPTION
This PR includes:
* Small change to make the deb package compatible with old debian version
* Changes on rpm spec file to allow it be built correctly on github actions
* Include actions to release the deb and rpm packages for dkms kernel module

Some points about the release of the packages:
* They should be attached to a tag . I have set the deb tag as kmod-*d* (for example kmod-3-d0), and the rpm tag as kmod-*r* (for example kmod-3-r1)
* All the release also will have the all the source code

These 2 points are a bit annoying, but I think to avoid them it will require a bit of work to implement an workflow (right now we are using one that already exists).

As an example 2 releases, one for deb and one for rpm:

https://github.com/gabrielfedel/mrfioc2/releases/tag/kmod-3-r1
https://github.com/gabrielfedel/mrfioc2/releases/tag/kmod-3-d0