### PR TITLE
fix: Fix inclusion of evrSupportBase7.dbd

### DIFF
--- a/evrApp/src/Makefile
+++ b/evrApp/src/Makefile
@@ -12,6 +12,9 @@ SRC_DIRS += evr
 USR_INCLUDES += -I$(TOP)/mrfCommon/src
 
 DBD += evrSupport.dbd
+ifdef BASE_7_0
+DBD += evrSupportBase7.dbd
+endif
 
 # INC += evr/pulser.h
 # INC += evr/output.h

--- a/mrfApp/src/Makefile
+++ b/mrfApp/src/Makefile
@@ -23,6 +23,11 @@ mrf_DBD += drvemSupport.dbd
 mrf_DBD += epicsvme.dbd
 mrf_DBD += epicspci.dbd
 
+ifdef BASE_7_0
+mrf_DBD += evrSupportBase7.dbd
+endif
+
+
 # Add all the support libraries needed by this IOC
 mrf_LIBS += evgmrm evrMrm evr mrmShared mrfCommon epicspci epicsvme
 


### PR DESCRIPTION
This dbd is used by the evreventutag.db, and without this fix the mrf.dbd wouldn't have it included. The change also include it to be built on dbd folder