### PR TITLE
fix: Use softclock if the registry empty for EVRU/D.

### DIFF
--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -595,7 +595,7 @@ void EVRMRM::clockSet(double freq)
         eventClock = (clk == 0.0) ? clk_soft : clk;
     }
 
-    printf("Set EVR %s clock %f newfrac %d (oldfrac %d)\n", model().c_str(), eventClock, newfrac, oldfrac);
+    printf("Set EVR %s %s clock %f newfrac %d (oldfrac %d)\n", model().c_str(), name().c_str(), eventClock, newfrac, oldfrac);
 
     // USecDiv is accessed as a 32 bit register, but
     // only 16 are used.
@@ -867,8 +867,8 @@ EVRMRM::convertTS(epicsTimeStamp* ts)
      */
     if(ts->secPastEpoch > lastValidTimestamp+1)
     {
-        errlogPrintf("EVR ignoring invalid TS %08x %08x (expect %08x)\n",
-                     ts->secPastEpoch, ts->nsec, lastValidTimestamp);
+        errlogPrintf("EVR %s %s ignoring invalid TS %08x %08x (expect %08x)\n",
+                    model().c_str(), name().c_str(), ts->secPastEpoch, ts->nsec, lastValidTimestamp);
         timestampValid=0;
         scanIoRequest(timestampValidChange);
         return false;

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -576,8 +576,7 @@ EVRMRM::clockSet(double freq)
 
     freq/=1e6;
 
-    epicsUInt32 newfrac=FracSynthControlWord(
-                        freq, fracref, 0, &err);
+    epicsUInt32 newfrac=FracSynthControlWord(freq, fracref, 0, &err);
 
     if(newfrac==0)
         throw std::out_of_range("New frequency can't be used");
@@ -593,8 +592,9 @@ EVRMRM::clockSet(double freq)
 
         WRITE32(base, FracDiv, newfrac);
 
-        eventClock=FracSynthAnalyze(READ32(base, FracDiv),
-                                    fracref,0)*1e6;
+        double clk = FracSynthAnalyze(READ32(base, FracDiv), fracref,0) * 1e6;
+        // Apply the soft clock if the registry is not implemented (EVRD/U)
+        eventClock = (clk == 0.0) ? clockTS() : clk;
     }
 
     // USecDiv is accessed as a 32 bit register, but

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -566,13 +566,11 @@ EVRMRM::specialSetMap(epicsUInt32 code, epicsUInt32 func,bool v)
     }
 }
 
-void
-EVRMRM::clockSet(double freq)
+// Set both the fractional synthesiser and microsecond divider.
+void EVRMRM::clockSet(double freq)
 {
     double err;
-    // Set both the fractional synthesiser and microsecond
-    // divider.
-    printf("Set EVR clock %f\n",freq);
+    double clk_soft = freq; //[Hz]
 
     freq/=1e6;
 
@@ -594,8 +592,10 @@ EVRMRM::clockSet(double freq)
 
         double clk = FracSynthAnalyze(READ32(base, FracDiv), fracref,0) * 1e6;
         // Apply the soft clock if the registry is not implemented (EVRD/U)
-        eventClock = (clk == 0.0) ? clockTS() : clk;
+        eventClock = (clk == 0.0) ? clk_soft : clk;
     }
+
+    printf("Set EVR %s clock %f newfrac %d (oldfrac %d)\n", model().c_str(), eventClock, newfrac, oldfrac);
 
     // USecDiv is accessed as a 32 bit register, but
     // only 16 are used.


### PR DESCRIPTION
@Insomnia1437 - please, review.