### PR TITLE
add evgMrmShared depends also on evrApp because of internval EVRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ mrmShared_DEPEND_DIRS += mrfCommon
 
 evrMrmApp_DEPEND_DIRS += evrApp mrmShared
 
-evgMrmApp_DEPEND_DIRS += mrmShared
+evgMrmApp_DEPEND_DIRS += evrApp mrmShared
 
 evrFRIBApp_DEPEND_DIRS += evrApp
 


### PR DESCRIPTION
Because of the internal EVRs in the EVMs, evgMrmApp depends on evrApp (through substitutions files). On a classical sequential compilation it is working, but on our Nix environment the compilation can be parallelized and sometimes we have compilation error because of this dependency.
```
 -S../mtca-evm-300.substitutions
 ERROR msi: Can't open file 'evrbase.db'
```

this modification should be transparent for classical compilation.

Is it possible to increase tag if merge is accepted please ? (minor 2.6.1)

Thanks