### PR TITLE
EVM-VME-300 Support

### DIFF
--- a/evgMrmApp/src/evgMxc.cpp
+++ b/evgMrmApp/src/evgMxc.cpp
@@ -64,7 +64,11 @@ evgMxc::getPrescaler() const {
 void
 evgMxc::setFrequency(epicsFloat64 freq) {
     epicsFloat64 clkSpeed = m_owner->getFrequency() * pow(10.0, 6);
+#if defined(vxWorks)
+    epicsUInt32 preScaler = (epicsUInt32)((epicsFloat64)clkSpeed / freq);
+#else
     epicsUInt32 preScaler = (epicsUInt32)lround(clkSpeed / freq);
+#endif
     setPrescaler(preScaler);
 }
 

--- a/mrfCommon/src/mrfcsr.h
+++ b/mrfCommon/src/mrfcsr.h
@@ -17,11 +17,13 @@
 #define MRF_VME_EVG_BID      0x45470000 /* VME Event Generator */
 #define MRF_VME_EVR_BID      0x45520000 /* VME Event Receiver */
 #define MRF_VME_EVR_RF_BID   0x45524600 /* VME Event Receiver with RF Recovery */
-#define MRF_VME_EVM_BID      0x4547012c /* VME-EVM-300 */
+#define MRF_VME_EVM_DC_BID   0x45470100 /* VME Event Master with Delay Compensation*/
+#define MRF_VME_EVR_DC_BID   0x45520100 /* VME Event Receiver with Delay Compensation*/
 
 #define MRF_SERIES_200       0x000000C8 /* Series 200 Code */
 #define MRF_SERIES_220       0x000000DC /* Series 220 Code */
 #define MRF_SERIES_230       0x000000E6 /* Series 230 Code */
+#define MRF_SERIES_300       0x0000002C /* Series 300 Code */
 
 /**************************************************************************************************/
 /*  Board ID Field Masks                                                                          */
@@ -49,6 +51,13 @@
 #define MRF_VME_EVG230_BID   (MRF_VME_EVG_BID    | MRF_SERIES_230) /* VME Event Generator 230     */
 #define MRF_VME_EVR230_BID   (MRF_VME_EVR_BID    | MRF_SERIES_230) /* VME Event Receiver 230      */
 #define MRF_VME_EVR230RF_BID (MRF_VME_EVR_RF_BID | MRF_SERIES_230) /* VME EVR 230 w/ RF Recovery  */
+
+/**************************************************************************************************/
+/*  Series 300 Board ID Codes                                                                     */
+/**************************************************************************************************/
+
+#define MRF_VME_EVM300_BID   (MRF_VME_EVM_DC_BID | MRF_SERIES_300) /* VME Event Generator 300     */
+#define MRF_VME_EVR300_BID   (MRF_VME_EVR_DC_BID | MRF_SERIES_300) /* VME Event Receiver 300     */
 
 /**************************************************************************************************/
 /*  CR/CSR User-CSR Space Offsets (MRF Specific)                                                  */


### PR DESCRIPTION
1: Adding configurations for EVM-VME-300 card so that it can be configured using mrmEvgSetupVME
2: Updated the board ID determination for the 300-series VME boards
3: The vxWorks compiler does not support C99, so functions like lround cannot be called. I added the vxWorks specific code where lround is called.