### PR TITLE
Fixed the AcTrigMap and added more options to AcTrig Sync Source

### DIFF
--- a/evgMrmApp/Db/evgAcTrig.db
+++ b/evgMrmApp/Db/evgAcTrig.db
@@ -77,23 +77,37 @@ record(bi, "$(P)Bypass-RB") {
   field(ONAM, "On")
 }
 
-record(bo, "$(P)SyncSrc-Sel") {
-  field(DESC, "Sync to Event Clock or Mxc7")
-  field(DTYP, "Obj Prop bool")
+record(mbbo, "$(P)SyncSrc-Sel") {
+  field(DESC, "Synchronization Source")
+  field(DTYP, "Obj Prop uint16")
   field(OUT,  "@OBJ=$(OBJ), PROP=SyncSrc")
   field(PINI, "YES")
+  field(ZRST, "Event Clk")
+  field(ONST, "Mxc7")
+  field(TWST, "FP IN1")
+  field(THST, "FP IN2")
+  field(ZRVL, "0x00")
+  field(ONVL, "0x01")
+  field(TWVL, "0x05")
+  field(THVL, "0x09")
   field(VAL , "0")
   field(UDF,  "0")
-  field(ZNAM, "Event Clk")
-  field(ONAM, "Mxc7")
   field(FLNK, "$(P)SyncSrc-RB")
   info(autosaveFields_pass0, "VAL")
 }
 
-record(bi, "$(P)SyncSrc-RB") {
-  field(DESC, "Sync to Event Clock or Mxc7")
-  field(DTYP, "Obj Prop bool")
+
+record(mbbi, "$(P)SyncSrc-RB") {
+  field(DESC, "Synchronization Source")
+  field(DTYP, "Obj Prop uint16")
   field(INP,  "@OBJ=$(OBJ), PROP=SyncSrc")
-  field(ZNAM, "Event Clk")
-  field(ONAM, "Mxc7")
+  field(ZRST, "Event Clk")
+  field(ONST, "Mxc7")
+  field(TWST, "FP IN1")
+  field(THST, "FP IN2")
+  field(ZRVL, "0x00")
+  field(ONVL, "0x01")
+  field(TWVL, "0x05")
+  field(THVL, "0x09")
 }
+

--- a/evgMrmApp/src/evgAcTrig.cpp
+++ b/evgMrmApp/src/evgAcTrig.cpp
@@ -65,18 +65,17 @@ evgAcTrig::getBypass() const {
     return !!(READ32(m_pReg, AcTrigControl)&AcTrigControl_Bypass);
 }
 
-
 void
-evgAcTrig::setSyncSrc(bool syncSrc) {
-    if(syncSrc)
-        BITSET32(m_pReg, AcTrigControl, AcTrigControl_Sync);
-    else
-        BITCLR32(m_pReg, AcTrigControl, AcTrigControl_Sync);
+evgAcTrig::setSyncSrc(epicsUInt16 syncSrc) {
+    epicsUInt32 cur = READ32(m_pReg, AcTrigControl);
+    cur &= ~AcTrigControl_Sync_MASK;
+    cur |= (epicsUInt8)syncSrc << AcTrigControl_Sync_SHIFT;
+    WRITE32(m_pReg, AcTrigControl, cur);
 }
 
-bool
+epicsUInt16
 evgAcTrig::getSyncSrc() const {
-    return !!(READ32(m_pReg, AcTrigControl)&AcTrigControl_Sync);
+    return (READ32(m_pReg, AcTrigControl)&AcTrigControl_Sync_MASK)>>AcTrigControl_Sync_SHIFT;
 }
 
 void

--- a/evgMrmApp/src/evgAcTrig.h
+++ b/evgMrmApp/src/evgAcTrig.h
@@ -22,8 +22,8 @@ public:
     void setBypass(bool);
     bool getBypass() const;
 
-    void setSyncSrc(bool);
-    bool getSyncSrc() const;
+    void setSyncSrc(epicsUInt16);
+    epicsUInt16 getSyncSrc() const;
 
     void setTrigEvtMap(epicsUInt16, bool);
     epicsUInt32 getTrigEvtMap() const;

--- a/evgMrmApp/src/evgRegMap.h
+++ b/evgMrmApp/src/evgRegMap.h
@@ -68,7 +68,8 @@
 //
 #define  U32_AcTrigControl      0x0010
 
-#define  AcTrigControl_Sync         0x00010000
+#define  AcTrigControl_Sync_MASK    0x000d0000
+#define  AcTrigControl_Sync_SHIFT   16
 #define  AcTrigControl_Bypass       0x00020000
 #define  AcTrigControl_Divider_MASK 0x0000ff00
 #define  AcTrigControl_Divider_SHIFT 8

--- a/evgMrmApp/src/evgRegMap.h
+++ b/evgMrmApp/src/evgRegMap.h
@@ -77,8 +77,8 @@
 
 #define  U32_AcTrigMap          0x0014
 
-#define  AcTrigMap_EvtMASK 0xff000000
-#define  AcTrigMap_EvtSHIFT 24
+#define  AcTrigMap_EvtMASK 0x000000ff
+#define  AcTrigMap_EvtSHIFT 0
 
 //=====================
 // Software Event Control Registers


### PR DESCRIPTION
I found a bug in the code. When trig event source is selected as AC Trig, it didn't generate any events. I looked through the manual and found the address of the AcTrigMap, and found that the Mask and Shift are not correct. 
Macros AcTrigMap_EvtMASK and AcTrigMap_EvtSHIFT are corrected.
After this fix, I added the feature to allow external synchronization sources for the AC trig, in another commit.
After these changes, I tested them and they worked. 
