### PR TITLE
Add the FLASH IO for the vme300 boards

### DIFF
--- a/evgMrmApp/src/evgMrm.cpp
+++ b/evgMrmApp/src/evgMrm.cpp
@@ -194,7 +194,7 @@ evgMrm::evgMrm(const std::string& id,
     
     scanIoInit(&ioScanTimestamp);
 
-    if((busConfig.busType==busType_pci) || (info.board==MRF_VME_EVM300_BID))
+    if(busConfig.busType==busType_pci || (busConfig.busType==busType_vme && version()>=MRFVersion(2, 0, 0)))
         mrf::SPIDevice::registerDev(id+":FLASH", mrf::SPIDevice(this, 1));
 
     if((pciDevice->id.sub_device==PCI_DEVICE_ID_MRF_MTCA_EVM_300) || (info.board==MRF_VME_EVM300_BID)) {
@@ -210,7 +210,7 @@ evgMrm::evgMrm(const std::string& id,
 }
 
 evgMrm::~evgMrm() {
-    if(getBusConfiguration()->busType==busType_pci)
+    if(getBusConfiguration()->busType==busType_pci || (getBusConfiguration()->busType==busType_vme && version()>=MRFVersion(2, 0, 0)))
         mrf::SPIDevice::unregisterDev(name()+":FLASH");
 
     for(size_t i = 0; i < m_trigEvt.size(); i++)

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -353,7 +353,7 @@ try{
 
     drain_fifo_task.start();
 
-    if(busConfig.busType==busType_pci)
+    if(busConfig.busType==busType_pci || (busConfig.busType==busType_vme && version()>=MRFVersion(2, 0, 0)))
         mrf::SPIDevice::registerDev(n+":FLASH", mrf::SPIDevice(this, 1));
 
     #ifndef DBR_UTAG
@@ -369,7 +369,7 @@ try{
 
 EVRMRM::~EVRMRM()
 {
-    if(getBusConfiguration()->busType==busType_pci)
+    if(getBusConfiguration()->busType==busType_pci || (getBusConfiguration()->busType==busType_vme && version()>=MRFVersion(2, 0, 0)))
         mrf::SPIDevice::unregisterDev(name()+":FLASH");
     cleanup();
 }

--- a/mrfCommon/src/flashiocsh.cpp
+++ b/mrfCommon/src/flashiocsh.cpp
@@ -165,7 +165,7 @@ void flashwrite(const char *name, int addrraw, const char *infile)
 
         std::ifstream strm(infile, std::ios_base::in|std::ios_base::binary);
         if(strm.fail())
-            throw std::runtime_error("Unable to open output file");
+            throw std::runtime_error("Unable to open input file");
 
         strm.seekg(0, std::ios_base::end);
         const long fsize = strm.tellg();


### PR DESCRIPTION
Add the flash IO for the EVM-VME-300 and EVR-VME-300.
Only cards with pci buses can have flash IO before. I just make it also available for cards with VME bus and firmware version higher than 2.0.

