### PR TITLE
database support for VME-300 cards and optimization of selection records

### DIFF
--- a/evgMrmApp/Db/Makefile
+++ b/evgMrmApp/Db/Makefile
@@ -34,6 +34,8 @@ DB += mtca-evm-300.db
 ifdef BASE_3_15
 DB += evm-mtca-300.uv.db
 DB += evm-mtca-300-evr.uv.db
+DB += evm-vme-300.db
+DB += evm-vme-300-evr.db
 endif
 
 ifneq ($(DEVIOCSTATS),)

--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -34,10 +34,30 @@ record(mbbo, "$(P)Src-Sel") {
   field(TTVL, "4096")
   field(FTVL, "8192")
   field(FFVL, "16384")
-
+  field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
-  field(OUT, "$(P)MapConv-Sel_ PP")
+  field(FLNK, "$(P)Src-SQ_.PROC PP")
   info(autosaveFields_pass0, "VAL")
+}
+
+record(seq, "$(P)Src-SQ_") {
+  field(DESC, "Sequence to control Src Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)Src1-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)Src2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)Src1-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)Src2-Sel.VAL PP NMS")
+  field(DOL5, "$(P)Src-Sel.VAL NPP NMS")
+  field(LNK5, "$(P)MapConv-Sel_ PP NMS")
+  field(DLY6, "0.3")
+  field(DOL6, "0")
+  field(LNK6, "$(P)Src1-SQ_.DISA NPP NMS")
+  field(DOL7, "0")
+  field(LNK7, "$(P)Src2-SQ_.DISA NPP NMS")
 }
 
 record(mbbo, "$(P)MapConv-Sel_") {
@@ -59,7 +79,168 @@ record(mbbo, "$(P)MapConv-Sel_") {
   field(TTVL, "1")
   field(FTVL, "2")
   field(FFVL, "3")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(OUT, "$(P)Map-Sel PP")
+  info(autosaveFields_pass0, "VAL")
+}
 
+record(mbbo, "$(P)Src1-Sel") {
+  field(DESC, "EVG DBUS Source (more)")
+  field(PINI, "YES")
+  field(VAL,  "0")
+  field(ZRST, "Off")
+  field(ONST, "Rear1")
+  field(TWST, "Rear2")
+  field(THST, "Rear3")
+  field(FRST, "Rear4")
+  field(FVST, "Rear5")
+  field(SXST, "Rear6")
+  field(SVST, "Rear7")
+  field(EIST, "Rear8")
+  field(NIST, "Rear9")
+  field(TEST, "Rear10")
+  field(ELST, "Rear11")
+  field(TVST, "Rear12")
+  field(TTST, "Rear13")
+  field(FTST, "Rear14")
+  field(FFST, "Rear15")
+  field(ZRVL, "0")
+  field(ONVL, "1")
+  field(TWVL, "2")
+  field(THVL, "4")
+  field(FRVL, "8")
+  field(FVVL, "16")
+  field(SXVL, "32")
+  field(SVVL, "64")
+  field(EIVL, "128")
+  field(NIVL, "256")
+  field(TEVL, "512")
+  field(ELVL, "1024")
+  field(TVVL, "2048")
+  field(TTVL, "4096")
+  field(FTVL, "8192")
+  field(FFVL, "16384")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(FLNK, "$(P)Src1-SQ_.PROC PP")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(seq, "$(P)Src1-SQ_") {
+  field(DESC, "Sequence to control Src1 Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)Src-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)Src2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)Src-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)Src2-Sel.VAL PP NMS")
+  field(DOL5, "$(P)Src1-Sel.VAL NPP NMS")
+  field(LNK5, "$(P)MapConv1-Sel_ PP NMS")
+  field(DLY6, "0.3")
+  field(DOL6, "0")
+  field(LNK6, "$(P)Src-SQ_.DISA NPP NMS")
+  field(DOL7, "0")
+  field(LNK7, "$(P)Src2-SQ_.DISA NPP NMS")
+}
+
+record(mbbo, "$(P)MapConv1-Sel_") {
+  field(ASG, "private")
+  field(DTYP, "Raw Soft Channel")
+  field(ZRVL, "0")
+  field(ONVL, "1")
+  field(TWVL, "1")
+  field(THVL, "1")
+  field(FRVL, "1")
+  field(FVVL, "1")
+  field(SXVL, "1")
+  field(SVVL, "1")
+  field(EIVL, "1")
+  field(NIVL, "1")
+  field(TEVL, "1")
+  field(ELVL, "1")
+  field(TVVL, "1")
+  field(TTVL, "1")
+  field(FTVL, "1")
+  field(FFVL, "1")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(OUT, "$(P)Map-Sel PP")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(mbbo, "$(P)Src2-Sel") {
+  field(DESC, "EVG DBUS Source (more+)")
+  field(PINI, "YES")
+  field(VAL,  "0")
+  field(ZRST, "Off")
+  field(ONST, "FrontInp2")
+  field(TWST, "Rear0")
+  field(ZRVL, "0")
+  field(ONVL, "1")
+  field(TWVL, "2")
+  field(THSV, "INVALID")
+  field(FRSV, "INVALID")
+  field(FVSV, "INVALID")
+  field(SXSV, "INVALID")
+  field(SVSV, "INVALID")
+  field(EISV, "INVALID")
+  field(NISV, "INVALID")
+  field(TESV, "INVALID")
+  field(ELSV, "INVALID")
+  field(TVSV, "INVALID")
+  field(TTSV, "INVALID")
+  field(FTSV, "INVALID")
+  field(FFSV, "INVALID")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(FLNK, "$(P)Src2-SQ_.PROC PP")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(seq, "$(P)Src2-SQ_") {
+  field(DESC, "Sequence to control Src1 Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)Src-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)Src1-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)Src-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)Src1-Sel.VAL PP NMS")
+  field(DOL5, "$(P)Src2-Sel.VAL NPP NMS")
+  field(LNK5, "$(P)MapConv2-Sel_ PP NMS")
+  field(DLY6, "0.3")
+  field(DOL6, "0")
+  field(LNK6, "$(P)Src-SQ_.DISA NPP NMS")
+  field(DOL7, "0")
+  field(LNK7, "$(P)Src1-SQ_.DISA NPP NMS")
+}
+
+record(mbbo, "$(P)MapConv2-Sel_") {
+  field(ASG, "private")
+  field(DTYP, "Raw Soft Channel")
+  field(ZRVL, "0")
+  field(ONVL, "1")
+  field(TWVL, "1")
+  field(THSV, "INVALID")
+  field(FRSV, "INVALID")
+  field(FVSV, "INVALID")
+  field(SXSV, "INVALID")
+  field(SVSV, "INVALID")
+  field(EISV, "INVALID")
+  field(NISV, "INVALID")
+  field(TESV, "INVALID")
+  field(ELSV, "INVALID")
+  field(TVSV, "INVALID")
+  field(TTSV, "INVALID")
+  field(FTSV, "INVALID")
+  field(FFSV, "INVALID")
+  field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
   field(OUT, "$(P)Map-Sel PP")
   info(autosaveFields_pass0, "VAL")
@@ -124,6 +305,16 @@ record(bo, "$(P)Src$(s=:)FrontInp1-Sel") {
   field(ONAM, "Set")
   field(OMSL, "closed_loop")
   field(DOL,  "$(P)Src-MbbiDir_.B1 CP")
+}
+
+record(bo, "$(P)Src$(s=:)FrontInp2-Sel") {
+  field(DESC, "Front Input1 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp2")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B0 CP")
 }
 
 record(bo, "$(P)Src$(s=:)UnivInp0-Sel") {
@@ -236,6 +427,166 @@ record(bo, "$(P)Src$(s=:)UnivInp10-Sel") {
   field(DOL,  "$(P)Src-MbbiDir_.BC CP")
 }
 
+record(bo, "$(P)Src$(s=:)RearInp0-Sel") {
+  field(DESC, "Front Rear Input0 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp0")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B1 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp1-Sel") {
+  field(DESC, "Front Rear Input1 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp1")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B0 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp2-Sel") {
+  field(DESC, "Front Rear Input2 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp2")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B1 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp3-Sel") {
+  field(DESC, "Front Rear Input3 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp3")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B2 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp4-Sel") {
+  field(DESC, "Front Rear Input4 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp4")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B3 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp5-Sel") {
+  field(DESC, "Front Rear Input5 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp5")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B4 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp6-Sel") {
+  field(DESC, "Front Rear Input6 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp6")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B5 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp7-Sel") {
+  field(DESC, "Front Rear Input7 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp7")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B6 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp8-Sel") {
+  field(DESC, "Front Rear Input8 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp8")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B7 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp9-Sel") {
+  field(DESC, "Front Rear Input9 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp9")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B8 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp10-Sel") {
+  field(DESC, "Front Rear Input10 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp10")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.B9 CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp11-Sel") {
+  field(DESC, "Front Rear Input11 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp11")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.BA CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp12-Sel") {
+  field(DESC, "Front Rear Input12 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp12")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.BB CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp13-Sel") {
+  field(DESC, "Front Rear Input13 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp13")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.BC CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp14-Sel") {
+  field(DESC, "Front Rear Input14 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp14")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.BD CP")
+}
+
+record(bo, "$(P)Src$(s=:)RearInp15-Sel") {
+  field(DESC, "Front Rear Input15 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp15")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src1-MbbiDir_.BE CP")
+}
+
 #
 # By default OMSL field for the *Src* records is "closed_loop" hence
 # only one Source can be selected due of MBBO record. If you want to select
@@ -249,6 +600,8 @@ record(dfanout, "$(P)Omsl-FOut") {
   field(OMSL, "supervisory")
   field(OUTA, "$(P)Omsl0-FOut_ PP")
   field(OUTB, "$(P)Omsl1-FOut_ PP")
+  field(OUTC, "$(P)Omsl2-FOut_ PP")
+  field(OUTD, "$(P)Omsl3-FOut_ PP")
   info(autosaveFields_pass0, "VAL")
 }
 
@@ -279,6 +632,39 @@ record(dfanout, "$(P)Omsl1-FOut_") {
   field(OUTC, "$(P)Src$(s=:)UnivInp8-Sel.OMSL")
   field(OUTD, "$(P)Src$(s=:)UnivInp9-Sel.OMSL")
   field(OUTE, "$(P)Src$(s=:)UnivInp10-Sel.OMSL")
+  field(OUTF, "$(P)Src$(s=:)FrontInp2-Sel.OMSL")
+}
+
+record(dfanout, "$(P)Omsl2-FOut_") {
+  field(ASG, "private")
+  #field(PINI, "YES")
+  field(VAL,  "1")
+  field(UDF,  "0")
+  field(OMSL, "supervisory")
+  field(OUTA, "$(P)Src$(s=:)RearInp0-Sel.OMSL")
+  field(OUTB, "$(P)Src$(s=:)RearInp1-Sel.OMSL")
+  field(OUTC, "$(P)Src$(s=:)RearInp2-Sel.OMSL")
+  field(OUTD, "$(P)Src$(s=:)RearInp3-Sel.OMSL")
+  field(OUTE, "$(P)Src$(s=:)RearInp4-Sel.OMSL")
+  field(OUTF, "$(P)Src$(s=:)RearInp5-Sel.OMSL")
+  field(OUTG, "$(P)Src$(s=:)RearInp6-Sel.OMSL")
+  field(OUTH, "$(P)Src$(s=:)RearInp7-Sel.OMSL")
+}
+
+record(dfanout, "$(P)Omsl3-FOut_") {
+  field(ASG, "private")
+  #field(PINI, "YES")
+  field(VAL,  "1")
+  field(UDF,  "0")
+  field(OMSL, "supervisory")
+  field(OUTA, "$(P)Src$(s=:)RearInp8-Sel.OMSL")
+  field(OUTB, "$(P)Src$(s=:)RearInp9-Sel.OMSL")
+  field(OUTC, "$(P)Src$(s=:)RearInp10-Sel.OMSL")
+  field(OUTD, "$(P)Src$(s=:)RearInp11-Sel.OMSL")
+  field(OUTE, "$(P)Src$(s=:)RearInp12-Sel.OMSL")
+  field(OUTF, "$(P)Src$(s=:)RearInp13-Sel.OMSL")
+  field(OUTG, "$(P)Src$(s=:)RearInp14-Sel.OMSL")
+  field(OUTH, "$(P)Src$(s=:)RearInp15-Sel.OMSL")
 }
 
 record(waveform, "$(P)Label-I") {

--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -157,9 +157,29 @@ record(mbbiDirect, "$(P)PpsInp-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp-Sel.RVAL NPP")
+  field(FLNK, "$(P)PpsInp-SQ_")
 }
+
+record(seq, "$(P)PpsInp-SQ_") {
+  field(DESC, "Sequence to control 1PPS Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)PpsInp1-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)PpsInp2-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+}
+
 record(mbbo, "$(P)PpsInp1-Sel") {
-  field(DESC, "EVG Pps Input")
+  field(DESC, "EVG Pps Input (more)")
   field(PINI, "YES")
   field(UDF,  "0")
   field(VAL,  "0")
@@ -170,6 +190,7 @@ record(mbbo, "$(P)PpsInp1-Sel") {
   field(FRST, "UnivInp14")
   field(FVST, "UnivInp15")
   field(SXST, "EPICS Scan")
+  field(SVST, "RearInp0")
   field(ZRVL, "0x0")
   field(ONVL, "0x1")
   field(TWVL, "0x2")
@@ -177,7 +198,7 @@ record(mbbo, "$(P)PpsInp1-Sel") {
   field(FRVL, "0x8")
   field(FVVL, "0x10")
   field(SXVL, "0x8000")
-  field(SVSV, "INVALID")
+  field(SVVL, "0x20")
   field(EISV, "INVALID")
   field(NISV, "INVALID")
   field(TESV, "INVALID")
@@ -200,7 +221,99 @@ record(mbbiDirect, "$(P)PpsInp1-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp1-Sel.RVAL NPP")
+  field(FLNK, "$(P)PpsInp1-SQ_")
 }
+
+record(seq, "$(P)PpsInp1-SQ_") {
+  field(DESC, "Sequence to control 1PPS Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)PpsInp-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)PpsInp2-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+}
+
+record(mbbo, "$(P)PpsInp2-Sel") {
+  field(DESC, "EVG Pps Input (more+)")
+  field(PINI, "YES")
+  field(UDF,  "0")
+  field(VAL,  "0")
+  field(ZRST, "None")
+  field(ONST, "Rear1")
+  field(TWST, "Rear2")
+  field(THST, "Rear3")
+  field(FRST, "Rear4")
+  field(FVST, "Rear5")
+  field(SXST, "Rear6")
+  field(SVST, "Rear7")
+  field(EIST, "Rear8")
+  field(NIST, "Rear9")
+  field(TEST, "Rear10")
+  field(ELST, "Rear11")
+  field(TVST, "Rear12")
+  field(TTST, "Rear13")
+  field(FTST, "Rear14")
+  field(FFST, "Rear15")
+  field(ZRVL, "0x0")
+  field(ONVL, "0x1")
+  field(TWVL, "0x2")
+  field(THVL, "0x4")
+  field(FRVL, "0x8")
+  field(FVVL, "0x10")
+  field(SXVL, "0x20")
+  field(SVVL, "0x40")
+  field(EIVL, "0x80")
+  field(NIVL, "0x100")
+  field(TEVL, "0x200")
+  field(ELVL, "0x400")
+  field(TVVL, "0x800")
+  field(TTVL, "0x1000")
+  field(FTVL, "0x2000")
+  field(FFVL, "0x4000")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(FLNK, "$(P)PpsInp2-MbbiDir_")
+  info(autosaveFields_pass0, "VAL")
+}
+
+#
+# Each bit of the PpsInp-MbbiDir record is used to toggle the external input
+# interrupt of the corresponding external input.
+#
+record(mbbiDirect, "$(P)PpsInp2-MbbiDir_") {
+  field(ASG, "private")
+  field(DESC, "EVG Pps Input")
+  field(INP,  "$(P)PpsInp2-Sel.RVAL NPP")
+  field(FLNK, "$(P)PpsInp2-SQ_")
+}
+
+record(seq, "$(P)PpsInp2-SQ_") {
+  field(DESC, "Sequence to control 1PPS Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)PpsInp-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)PpsInp1-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+}
+
 record(longin, "$(P)DbusStatus-RB" ) {
   field(DESC, "EVG Dbus Status")
   field(DTYP, "Obj Prop uint32")

--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -145,7 +145,7 @@ record(mbbo, "$(P)PpsInp-Sel") {
   field(FFVL, "0x2000")
   field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
-  field(FLNK, "$(P)PpsInp-MbbiDir_")
+  field(FLNK, "$(P)PpsInp-SQ_")
   info(autosaveFields_pass0, "VAL")
 }
 
@@ -157,15 +157,21 @@ record(mbbiDirect, "$(P)PpsInp-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp-Sel.RVAL NPP")
-  field(FLNK, "$(P)PpsInp-SQ_")
 }
 
-record(seq, "$(P)PpsInp-SQ_") {
+record(seq, "$(P)PpsInp-SQ_"){
+  field(DOL1, "0")
+  field(LNK1, "$(P)PpsInpItlk-SQ_.PROC")
+  field(DOL2, "0")
+  field(LNK2, "$(P)PpsInp-MbbiDir_.PROC")
+}
+
+record(seq, "$(P)PpsInpItlk-SQ_") {
   field(DESC, "Sequence to control 1PPS Select")
   field(DOL1, "1")
-  field(LNK1, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(LNK1, "$(P)PpsInp1Itlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
-  field(LNK2, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(LNK2, "$(P)PpsInp2Itlk-SQ_.DISA NPP NMS")
   field(DLY3, "0.3")
   field(DOL3, "0")
   field(LNK3, "$(P)PpsInp1-Sel.VAL PP NMS")
@@ -173,9 +179,9 @@ record(seq, "$(P)PpsInp-SQ_") {
   field(LNK4, "$(P)PpsInp2-Sel.VAL PP NMS")
   field(DLY5, "0.3")
   field(DOL5, "0")
-  field(LNK5, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(LNK5, "$(P)PpsInp1Itlk-SQ_.DISA NPP NMS")
   field(DOL6, "0")
-  field(LNK6, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(LNK6, "$(P)PpsInp2Itlk-SQ_.DISA NPP NMS")
 }
 
 record(mbbo, "$(P)PpsInp1-Sel") {
@@ -209,7 +215,7 @@ record(mbbo, "$(P)PpsInp1-Sel") {
   field(FFSV, "INVALID")
   field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
-  field(FLNK, "$(P)PpsInp1-MbbiDir_")
+  field(FLNK, "$(P)PpsInp1-SQ_")
   info(autosaveFields_pass0, "VAL")
 }
 
@@ -221,15 +227,21 @@ record(mbbiDirect, "$(P)PpsInp1-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp1-Sel.RVAL NPP")
-  field(FLNK, "$(P)PpsInp1-SQ_")
 }
 
-record(seq, "$(P)PpsInp1-SQ_") {
+record(seq, "$(P)PpsInp1-SQ_"){
+  field(DOL1, "0")
+  field(LNK1, "$(P)PpsInp1Itlk-SQ_.PROC")
+  field(DOL2, "0")
+  field(LNK2, "$(P)PpsInp1-MbbiDir_.PROC")
+}
+
+record(seq, "$(P)PpsInp1Itlk-SQ_") {
   field(DESC, "Sequence to control 1PPS Select")
   field(DOL1, "1")
-  field(LNK1, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(LNK1, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
-  field(LNK2, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(LNK2, "$(P)PpsInp2Itlk-SQ_.DISA NPP NMS")
   field(DLY3, "0.3")
   field(DOL3, "0")
   field(LNK3, "$(P)PpsInp-Sel.VAL PP NMS")
@@ -237,9 +249,9 @@ record(seq, "$(P)PpsInp1-SQ_") {
   field(LNK4, "$(P)PpsInp2-Sel.VAL PP NMS")
   field(DLY5, "0.3")
   field(DOL5, "0")
-  field(LNK5, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(LNK5, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
   field(DOL6, "0")
-  field(LNK6, "$(P)PpsInp2-SQ_.DISA NPP NMS")
+  field(LNK6, "$(P)PpsInp2Itlk-SQ_.DISA NPP NMS")
 }
 
 record(mbbo, "$(P)PpsInp2-Sel") {
@@ -281,7 +293,7 @@ record(mbbo, "$(P)PpsInp2-Sel") {
   field(FFVL, "0x4000")
   field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
-  field(FLNK, "$(P)PpsInp2-MbbiDir_")
+  field(FLNK, "$(P)PpsInp2-SQ_")
   info(autosaveFields_pass0, "VAL")
 }
 
@@ -293,15 +305,21 @@ record(mbbiDirect, "$(P)PpsInp2-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp2-Sel.RVAL NPP")
-  field(FLNK, "$(P)PpsInp2-SQ_")
 }
 
-record(seq, "$(P)PpsInp2-SQ_") {
+record(seq, "$(P)PpsInp2-SQ_"){
+  field(DOL1, "0")
+  field(LNK1, "$(P)PpsInp2Itlk-SQ_.PROC")
+  field(DOL2, "0")
+  field(LNK2, "$(P)PpsInp2-MbbiDir_.PROC")
+}
+
+record(seq, "$(P)PpsInp2Itlk-SQ_") {
   field(DESC, "Sequence to control 1PPS Select")
   field(DOL1, "1")
-  field(LNK1, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(LNK1, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
-  field(LNK2, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(LNK2, "$(P)PpsInp1Itlk-SQ_.DISA NPP NMS")
   field(DLY3, "0.3")
   field(DOL3, "0")
   field(LNK3, "$(P)PpsInp-Sel.VAL PP NMS")
@@ -309,9 +327,9 @@ record(seq, "$(P)PpsInp2-SQ_") {
   field(LNK4, "$(P)PpsInp1-Sel.VAL PP NMS")
   field(DLY5, "0.3")
   field(DOL5, "0")
-  field(LNK5, "$(P)PpsInp-SQ_.DISA NPP NMS")
+  field(LNK5, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
   field(DOL6, "0")
-  field(LNK6, "$(P)PpsInp1-SQ_.DISA NPP NMS")
+  field(LNK6, "$(P)PpsInp1Itlk-SQ_.DISA NPP NMS")
 }
 
 record(longin, "$(P)DbusStatus-RB" ) {

--- a/evgMrmApp/Db/evgTrigEvt.db
+++ b/evgMrmApp/Db/evgTrigEvt.db
@@ -71,10 +71,29 @@ record(mbbiDirect, "$(P)TrigSrc-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Trig Evt Trig")
   field(INP,  "$(P)TrigSrc-Sel.RVAL")
+  field(FLNK, "$(P)TrigSrc-SQ_")
+}
+
+record(seq, "$(P)TrigSrc-SQ_") {
+  field(DESC, "Sequence to control TrigSrc Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)TrigSrc1-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)TrigSrc2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)TrigSrc1-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)TrigSrc2-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)TrigSrc1-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)TrigSrc2-SQ_.DISA NPP NMS")
 }
 
 record(mbbo, "$(P)TrigSrc1-Sel") {
-  field(DESC, "EVG Trig Evt Trig")
+  field(DESC, "EVG Trig Evt Trig (more)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -91,6 +110,8 @@ record(mbbo, "$(P)TrigSrc1-Sel") {
   field(TEST, "Univ13")
   field(ELST, "Univ14")
   field(TVST, "Univ15")
+  field(TTST, "Front2")
+  field(FTST, "Rear0")
   field(ZRVL, "0")
   field(ONVL, "1")
   field(TWVL, "2")
@@ -104,8 +125,8 @@ record(mbbo, "$(P)TrigSrc1-Sel") {
   field(TEVL, "512")
   field(ELVL, "1024")
   field(TVVL, "2048")
-  field(TTSV, "INVALID")
-  field(FTSV, "INVALID")
+  field(TTVL, "4096")
+  field(FTVL, "8192")
   field(FFSV, "INVALID")
   field(UNSV, "INVALID")
   field(IVOA, "Don't drive outputs")
@@ -117,6 +138,93 @@ record(mbbiDirect, "$(P)TrigSrc1-MbbiDir_") {
   field(ASG, "private")
   field(DESC, "EVG Trig Evt Trig")
   field(INP,  "$(P)TrigSrc1-Sel.RVAL")
+  field(FLNK, "$(P)TrigSrc1-SQ_")
+}
+
+record(seq, "$(P)TrigSrc1-SQ_") {
+  field(DESC, "Sequence to control TrigSrc Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)TrigSrc-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)TrigSrc2-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)TrigSrc-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)TrigSrc2-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)TrigSrc-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)TrigSrc2-SQ_.DISA NPP NMS")
+}
+
+record(mbbo, "$(P)TrigSrc2-Sel") {
+  field(DESC, "EVG Trig Evt Trig (more+)")
+  field(PINI, "YES")
+  field(VAL,  "0")
+  field(UDF,  "0")
+  field(ZRST, "Off")
+  field(ONST, "Rear1")
+  field(TWST, "Rear2")
+  field(THST, "Rear3")
+  field(FRST, "Rear4")
+  field(FVST, "Rear5")
+  field(SXST, "Rear6")
+  field(SVST, "Rear7")
+  field(EIST, "Rear8")
+  field(NIST, "Rear9")
+  field(TEST, "Rear10")
+  field(ELST, "Rear11")
+  field(TVST, "Rear12")
+  field(TTST, "Rear13")
+  field(FTST, "Rear14")
+  field(FFST, "Rear15")
+  field(ZRVL, "0")
+  field(ONVL, "1")
+  field(TWVL, "2")
+  field(THVL, "4")
+  field(FRVL, "8")
+  field(FVVL, "16")
+  field(SXVL, "32")
+  field(SVVL, "64")
+  field(EIVL, "128")
+  field(NIVL, "256")
+  field(TEVL, "512")
+  field(ELVL, "1024")
+  field(TVVL, "2048")
+  field(TTVL, "4096")
+  field(FTVL, "8192")
+  field(FFVL, "16384")
+  field(UNSV, "INVALID")
+  field(IVOA, "Don't drive outputs")
+  field(FLNK, "$(P)TrigSrc2-MbbiDir_")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(mbbiDirect, "$(P)TrigSrc2-MbbiDir_") {
+  field(ASG, "private")
+  field(DESC, "EVG Trig Evt Trig")
+  field(INP,  "$(P)TrigSrc2-Sel.RVAL")
+  field(FLNK, "$(P)TrigSrc2-SQ_")
+}
+
+record(seq, "$(P)TrigSrc2-SQ_") {
+  field(DESC, "Sequence to control TrigSrc Select")
+  field(DOL1, "1")
+  field(LNK1, "$(P)TrigSrc-SQ_.DISA NPP NMS")
+  field(DOL2, "1")
+  field(LNK2, "$(P)TrigSrc1-SQ_.DISA NPP NMS")
+  field(DLY3, "0.3")
+  field(DOL3, "0")
+  field(LNK3, "$(P)TrigSrc-Sel.VAL PP NMS")
+  field(DOL4, "0")
+  field(LNK4, "$(P)TrigSrc1-Sel.VAL PP NMS")
+  field(DLY5, "0.3")
+  field(DOL5, "0")
+  field(LNK5, "$(P)TrigSrc-SQ_.DISA NPP NMS")
+  field(DOL6, "0")
+  field(LNK6, "$(P)TrigSrc1-SQ_.DISA NPP NMS")
 }
 
 record(bo, "$(P)TrigSrc$(s=:)Mxc0-Sel") {
@@ -346,6 +454,143 @@ record(bo, "$(P)TrigSrc$(s=:)UnivInp15-Sel") {
   field(DOL,  "$(P)TrigSrc1-MbbiDir_.BB CP")
 }
 
+record(bo, "$(P)TrigSrc$(s=:)FrontInp2-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp2")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)TrigSrc1-MbbiDir_.BC CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp0-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp0")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc1-MbbiDir_.BD CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp1-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp1")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B0 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp2-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp2")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B1 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp3-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp3")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B2 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp4-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp4")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B3 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp5-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp5")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B4 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp6-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp6")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B5 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp7-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp7")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B6 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp8-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp8")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B7 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp9-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp9")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B8 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp10-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp10")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.B9 CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp11-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp11")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.BA CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp12-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp12")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.BB CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp13-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp13")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.BC CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp14-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp14")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.BD CP")
+}
+
+record(bo, "$(P)TrigSrc$(s=:)RearInp15-Sel") {
+  field(DTYP, "EVG TrigEvt")
+  field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp15")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(DOL,  "$(P)TrigSrc2-MbbiDir_.BE CP")
+}
+
 #
 # By default OMSL field for the *TrigSrc* records is "closed_loop" hence
 # only one Source can be selected due of MBBO record. If you want to select
@@ -377,10 +622,11 @@ record(dfanout, "$(P)Omsl$(s=:)Cont-FOut_") {
   field(OUTA, "$(P)TrigSrc$(s=:)AC-Sel.OMSL")
   field(OUTB, "$(P)TrigSrc$(s=:)FrontInp0-Sel.OMSL")
   field(OUTC, "$(P)TrigSrc$(s=:)FrontInp1-Sel.OMSL")
-  field(OUTD, "$(P)TrigSrc$(s=:)UnivInp0-Sel.OMSL")
-  field(OUTE, "$(P)TrigSrc$(s=:)UnivInp1-Sel.OMSL")
-  field(OUTF, "$(P)TrigSrc$(s=:)UnivInp2-Sel.OMSL")
-  field(OUTG, "$(P)TrigSrc$(s=:)UnivInp3-Sel.OMSL")
+  field(OUTD, "$(P)TrigSrc$(s=:)FrontInp2-Sel.OMSL")
+  field(OUTE, "$(P)TrigSrc$(s=:)UnivInp0-Sel.OMSL")
+  field(OUTF, "$(P)TrigSrc$(s=:)UnivInp1-Sel.OMSL")
+  field(OUTG, "$(P)TrigSrc$(s=:)UnivInp2-Sel.OMSL")
+  field(OUTH, "$(P)TrigSrc$(s=:)UnivInp3-Sel.OMSL")
   field(FLNK, "$(P)Omsl$(s=:)Cont1-FOut_")
 }
 
@@ -407,6 +653,36 @@ record(dfanout, "$(P)Omsl$(s=:)Cont2-FOut_") {
   field(OUTB, "$(P)TrigSrc$(s=:)UnivInp13-Sel.OMSL")
   field(OUTC, "$(P)TrigSrc$(s=:)UnivInp14-Sel.OMSL")
   field(OUTD, "$(P)TrigSrc$(s=:)UnivInp15-Sel.OMSL")
+  field(OUTE, "$(P)TrigSrc$(s=:)RearInp0-Sel.OMSL")
+  field(OUTF, "$(P)TrigSrc$(s=:)RearInp1-Sel.OMSL")
+  field(OUTG, "$(P)TrigSrc$(s=:)RearInp2-Sel.OMSL")
+  field(OUTH, "$(P)TrigSrc$(s=:)RearInp3-Sel.OMSL")
+  field(FLNK, "$(P)Omsl$(s=:)Cont3-FOut_")
+}
+
+record(dfanout, "$(P)Omsl$(s=:)Cont3-FOut_") {
+  field(ASG, "private")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Omsl-FOut")
+  field(OUTA, "$(P)TrigSrc$(s=:)RearInp4-Sel.OMSL")
+  field(OUTB, "$(P)TrigSrc$(s=:)RearInp5-Sel.OMSL")
+  field(OUTC, "$(P)TrigSrc$(s=:)RearInp6-Sel.OMSL")
+  field(OUTD, "$(P)TrigSrc$(s=:)RearInp7-Sel.OMSL")
+  field(OUTE, "$(P)TrigSrc$(s=:)RearInp8-Sel.OMSL")
+  field(OUTF, "$(P)TrigSrc$(s=:)RearInp9-Sel.OMSL")
+  field(OUTG, "$(P)TrigSrc$(s=:)RearInp10-Sel.OMSL")
+  field(OUTH, "$(P)TrigSrc$(s=:)RearInp11-Sel.OMSL")
+  field(FLNK, "$(P)Omsl$(s=:)Cont4-FOut_")
+}
+
+record(dfanout, "$(P)Omsl$(s=:)Cont4-FOut_") {
+  field(ASG, "private")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Omsl-FOut")
+  field(OUTA, "$(P)TrigSrc$(s=:)RearInp12-Sel.OMSL")
+  field(OUTB, "$(P)TrigSrc$(s=:)RearInp13-Sel.OMSL")
+  field(OUTC, "$(P)TrigSrc$(s=:)RearInp14-Sel.OMSL")
+  field(OUTD, "$(P)TrigSrc$(s=:)RearInp15-Sel.OMSL")
 }
 
 record(waveform, "$(P)Label-I") {

--- a/evgMrmApp/Db/evm-vme-300-evr.substitutions
+++ b/evgMrmApp/Db/evm-vme-300-evr.substitutions
@@ -1,0 +1,309 @@
+# Naming-agnostic
+# ===============
+## s unused separator, backward compatibility purposes
+global {s=""}
+
+# P - Prefix
+# T - Embedded EVR type: e.g. {U,D} ~ {upstream,downstream}, assumptions !U=D !D=U
+# The rest follows the standard EVR
+
+### Embedded EVR Core within EVM ###
+
+file "evrbase.db"
+{
+{P="\$(P)", OBJ="$(EVG):EVR$(T)", EVNT1HZ="125", FEVT="\$(FEVT=124.916)"}
+}
+
+file "mrmevrdc.template"
+{
+{P="\$(P)DC", OBJ="$(EVG):EVR$(T)"}
+}
+
+file "evrevent.db"
+{pattern
+{EN, OBJ, CODE, EVNT}
+{"\$(P)Pps",  "$(EVG):EVR$(T)", 0x7d, 125}
+{"\$(P)EvtA", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtB", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtC", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtD", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtE", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtF", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtG", "$(EVG):EVR$(T)", 255,  255}
+{"\$(P)EvtH", "$(EVG):EVR$(T)", 255,  255}
+}
+
+file "evrscale.db"
+{pattern
+{IDX, P, SN, OBJ, EVR, MAX}
+{0, "\$(P)", "\$(P)PS$(IDX)", "$(EVG):EVR$(T):PS$(IDX)", "$(EVG):EVR$(T)", "0xffffffff"}
+{1, "\$(P)", "\$(P)PS$(IDX)", "$(EVG):EVR$(T):PS$(IDX)", "$(EVG):EVR$(T)", "0xffffffff"}
+{2, "\$(P)", "\$(P)PS$(IDX)", "$(EVG):EVR$(T):PS$(IDX)", "$(EVG):EVR$(T)", "0xffffffff"}
+}
+
+file "evrin.db"
+{pattern
+{IN, OBJ, DESC}
+{"\$(P)InFP0", "$(EVG):EVR$(T):FPIn0", "$(T)FPIN0 <- !$(T)FP0"}
+{"\$(P)InFP1", "$(EVG):EVR$(T):FPIn1", "$(T)FPIN1 <- !$(T)FP1"}
+{"\$(P)InFP2", "$(EVG):EVR$(T):FPIn2", "$(T)FPIN2 <- !$(T)FP2"}
+{"\$(P)InFP3", "$(EVG):EVR$(T):FPIn3", "$(T)FPIN3 <- !$(T)FP3"}
+{"\$(P)InFP4", "$(EVG):EVR$(T):FPIn4", "$(T)FPIN4 <- !$(T)FP4"}
+{"\$(P)InFP5", "$(EVG):EVR$(T):FPIn5", "$(T)FPIN5 <- !$(T)FP5"}
+{"\$(P)InFP6", "$(EVG):EVR$(T):FPIn6", "$(T)FPIN6 <- !$(T)FP6"}
+{"\$(P)InFP7", "$(EVG):EVR$(T):FPIn7", "$(T)FPIN7 <- !$(T)FP7"}
+}
+
+file "mrmevrout.db"
+{pattern
+{ON, OBJ, DESC}
+{"\$(P)OutFP0", "$(EVG):EVR$(T):FrontOut0", "InEVG[$(T)==D?0:8]&!$(T)InFP0"}
+{"\$(P)OutFP1", "$(EVG):EVR$(T):FrontOut1", "InEVG[$(T)==D?1:9]&!$(T)InFP0"}
+{"\$(P)OutFP2", "$(EVG):EVR$(T):FrontOut2", "InEVG[$(T)==D?2:10]&!$(T)InFP0"}
+{"\$(P)OutFP3", "$(EVG):EVR$(T):FrontOut3", "InEVG[$(T)==D?3:11]&!$(T)InFP0"}
+{"\$(P)OutFP4", "$(EVG):EVR$(T):FrontOut4", "InEVG[$(T)==D?4:12]&!$(T)InFP0"}
+{"\$(P)OutFP5", "$(EVG):EVR$(T):FrontOut5", "InEVG[$(T)==D?5:13]&!$(T)InFP0"}
+{"\$(P)OutFP6", "$(EVG):EVR$(T):FrontOut6", "InEVG[$(T)==D?6:14]&!$(T)InFP0"}
+{"\$(P)OutFP7", "$(EVG):EVR$(T):FrontOut7", "InEVG[$(T)==D?7:15]&!$(T)InFP0"}
+}
+
+# Pulse generators w/o a prescaler set NOPS=1
+file "evrpulser.db"
+{pattern
+{PID, P, PN, OBJ, DMAX, WMAX, PMAX, NOPS}
+{0, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{5, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{6, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{7, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{8, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{9, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{10,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{11,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{12,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{13,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{14,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{15,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+# gate generators
+{28,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{29,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{30,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{31,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+}
+
+# Default to 3 possible trigger mappings per pulser
+file "evrpulsermap.db"
+{pattern
+{PID, NAME, OBJ, F, EVT}
+{0, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{0, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{0, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{28,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{28,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVG):EVR$(T):Pul$(PID)", Trig, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVG):EVR$(T):Pul$(PID)", Set, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVG):EVR$(T):Pul$(PID)", Reset, 0}
+}
+
+# pulser masking controls
+file "evrdcpulser.template"
+{pattern
+{PID, P, PN, OBJ}
+{0,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{1,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{2,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{3,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{4,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{5,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{6,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{7,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{8,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{9,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{10, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{11, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{12, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{13, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{14, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+{15, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVG):EVR$(T):Pul$(PID)"}
+}
+

--- a/evgMrmApp/Db/evm-vme-300.substitutions
+++ b/evgMrmApp/Db/evm-vme-300.substitutions
@@ -1,0 +1,144 @@
+# Naming-agnostic
+# ===============
+## s unused separator, backward compatibility purposes
+## PP is required for: evgInput.db, evgMxc.db, evgSoftSeq.template
+global {s="", PP="\$(P)"}
+
+### EVG Core ###
+
+file "evgAcTrig.db"
+{pattern
+{P, OBJ}
+{"\$(P)AcTrig", "$(EVG):AcTrig"}
+}
+
+file "evgDbus-vme300.db"
+{
+pattern
+{P, OBJ, EVG, dbusBit}
+{"\$(P)Dbus0", "$(EVG):Dbus0", $(EVG), 0}
+{"\$(P)Dbus1", "$(EVG):Dbus1", $(EVG), 1}
+{"\$(P)Dbus2", "$(EVG):Dbus2", $(EVG), 2}
+{"\$(P)Dbus3", "$(EVG):Dbus3", $(EVG), 3}
+{"\$(P)Dbus4", "$(EVG):Dbus4", $(EVG), 4}
+{"\$(P)Dbus5", "$(EVG):Dbus5", $(EVG), 5}
+{"\$(P)Dbus6", "$(EVG):Dbus6", $(EVG), 6}
+{"\$(P)Dbus7", "$(EVG):Dbus7", $(EVG), 7}
+}
+
+file "evgEvtClk.db"
+{
+{P="\$(P)EvtClk", OBJ="$(EVG)", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+}
+
+file "evgInput.db"
+{pattern
+{P, OBJ, Num}
+# The $(Num) are not sequential to avoid breaking historical autosave files
+{"\$(P)InpFront0", "$(EVG):FrontInp0",  0}
+{"\$(P)InpFront1", "$(EVG):FrontInp1",  1}
+{"\$(P)InpFront2", "$(EVG):FrontInp2",  2}
+{"\$(P)InpRear10", "$(EVG):RearInp10",  3}
+{"\$(P)InpRear11", "$(EVG):RearInp11",  4}
+{"\$(P)InpRear12", "$(EVG):RearInp12",  5}
+{"\$(P)InpRear13", "$(EVG):RearInp13",  6}
+{"\$(P)InpRear14", "$(EVG):RearInp14",  7}
+{"\$(P)InpRear15", "$(EVG):RearInp15",  8}
+pattern
+{P, OBJ, Num, CONT}
+{"\$(P)InpRear0",  "$(EVG):RearInp0",   0, "1"}
+{"\$(P)InpRear1",  "$(EVG):RearInp1",   1, "1"}
+{"\$(P)InpRear2",  "$(EVG):RearInp2",   2, "1"}
+{"\$(P)InpRear3",  "$(EVG):RearInp3",   3, "1"}
+{"\$(P)InpRear4",  "$(EVG):RearInp4",   4, "1"}
+{"\$(P)InpRear5",  "$(EVG):RearInp5",   5, "1"}
+{"\$(P)InpRear6",  "$(EVG):RearInp6",   6, "1"}
+{"\$(P)InpRear7",  "$(EVG):RearInp7",   7, "1"}
+{"\$(P)InpRear8",  "$(EVG):RearInp8",   8, "1"}
+{"\$(P)InpRear9",  "$(EVG):RearInp9",   9, "1"}
+}
+
+file "evgMrm-vme300.db"
+{
+{P="\$(P)", SOFTEVT="\$(P)SoftEvt", OBJ="$(EVG)", EVG="$(EVG)"}
+}
+
+file "evgMxc.db"
+{pattern
+{P, OBJ}
+{"\$(P)Mxc0", "$(EVG):Mxc0"}
+{"\$(P)Mxc1", "$(EVG):Mxc1"}
+{"\$(P)Mxc2", "$(EVG):Mxc2"}
+{"\$(P)Mxc3", "$(EVG):Mxc3"}
+{"\$(P)Mxc4", "$(EVG):Mxc4"}
+{"\$(P)Mxc5", "$(EVG):Mxc5"}
+{"\$(P)Mxc6", "$(EVG):Mxc6"}
+{"\$(P)Mxc7", "$(EVG):Mxc7"}
+}
+
+file "evgOutput.db"
+{pattern
+{P, OBJ}
+{"\$(P)OutFront0", "$(EVG):FrontOut0"}
+{"\$(P)OutFront1", "$(EVG):FrontOut1"}
+{"\$(P)OutFront2", "$(EVG):FrontOut2"}
+{"\$(P)OutFront3", "$(EVG):FrontOut3"}
+}
+
+file "mrmSoftSeq.template"
+{pattern
+{P, EVG, seqNum, NELM}
+{"\$(P)SoftSeq0", $(EVG), 0, 2047}
+{"\$(P)SoftSeq1", $(EVG), 1, 2047}
+}
+
+file "evgSoftSeq.template"
+{pattern
+{P, EVG, seqNum, NELM}
+{"\$(P)SoftSeq0", $(EVG), 0, 2047}
+{"\$(P)SoftSeq1", $(EVG), 1, 2047}
+}
+
+file "evgTrigEvt-vme300.db"
+{pattern
+{P, OBJ, EVG, trigEvtNum}
+{"\$(P)TrigEvt0", "$(EVG):TrigEvt0", $(EVG), 0}
+{"\$(P)TrigEvt1", "$(EVG):TrigEvt1", $(EVG), 1}
+{"\$(P)TrigEvt2", "$(EVG):TrigEvt2", $(EVG), 2}
+{"\$(P)TrigEvt3", "$(EVG):TrigEvt3", $(EVG), 3}
+{"\$(P)TrigEvt4", "$(EVG):TrigEvt4", $(EVG), 4}
+{"\$(P)TrigEvt5", "$(EVG):TrigEvt5", $(EVG), 5}
+{"\$(P)TrigEvt6", "$(EVG):TrigEvt6", $(EVG), 6}
+{"\$(P)TrigEvt7", "$(EVG):TrigEvt7", $(EVG), 7}
+}
+
+file "databuftx.db"
+{pattern
+{P, OBJ, PROTO, s}
+{"\$(P)", "$(EVG):BUFTX", 1, "-"}
+}
+
+file "databuftxCtrl.db"
+{pattern
+{P, OBJ}
+{"\$(P)", "$(EVG):BUFTX"}
+}
+
+### FCT Core
+
+file "evm-fct.template"
+{
+{P="\$(P)FCT", OBJ="$(EVG):FCT"}
+}
+
+file "sfp.db"
+{
+{P="\$(P)SFP1", OBJ="$(EVG):FCT:SFP1"}
+{P="\$(P)SFP2", OBJ="$(EVG):FCT:SFP2"}
+{P="\$(P)SFP3", OBJ="$(EVG):FCT:SFP3"}
+{P="\$(P)SFP4", OBJ="$(EVG):FCT:SFP4"}
+{P="\$(P)SFP5", OBJ="$(EVG):FCT:SFP5"}
+{P="\$(P)SFP6", OBJ="$(EVG):FCT:SFP6"}
+{P="\$(P)SFP7", OBJ="$(EVG):FCT:SFP7"}
+{P="\$(P)SFP8", OBJ="$(EVG):FCT:SFP8"}
+}

--- a/evgMrmApp/Db/evm-vme-300.substitutions
+++ b/evgMrmApp/Db/evm-vme-300.substitutions
@@ -12,7 +12,7 @@ file "evgAcTrig.db"
 {"\$(P)AcTrig", "$(EVG):AcTrig"}
 }
 
-file "evgDbus-vme300.db"
+file "evgDbus.db"
 {
 pattern
 {P, OBJ, EVG, dbusBit}
@@ -37,28 +37,44 @@ file "evgInput.db"
 # The $(Num) are not sequential to avoid breaking historical autosave files
 {"\$(P)InpFront0", "$(EVG):FrontInp0",  0}
 {"\$(P)InpFront1", "$(EVG):FrontInp1",  1}
-{"\$(P)InpFront2", "$(EVG):FrontInp2",  2}
-{"\$(P)InpRear10", "$(EVG):RearInp10",  3}
-{"\$(P)InpRear11", "$(EVG):RearInp11",  4}
-{"\$(P)InpRear12", "$(EVG):RearInp12",  5}
-{"\$(P)InpRear13", "$(EVG):RearInp13",  6}
-{"\$(P)InpRear14", "$(EVG):RearInp14",  7}
-{"\$(P)InpRear15", "$(EVG):RearInp15",  8}
+{"\$(P)InpUniv0",  "$(EVG):UnivInp0",   2}
+{"\$(P)InpUniv1",  "$(EVG):UnivInp1",   3}
+{"\$(P)InpUniv2",  "$(EVG):UnivInp2",   4}
+{"\$(P)InpUniv3",  "$(EVG):UnivInp3",   5}
+{"\$(P)InpFront2", "$(EVG):FrontInp2",  6}
+{"\$(P)InpUniv4",  "$(EVG):UnivInp4",   7}
+{"\$(P)InpUniv5",  "$(EVG):UnivInp5",   8}
+{"\$(P)InpUniv6",  "$(EVG):UnivInp6",   9}
+{"\$(P)InpUniv7",  "$(EVG):UnivInp7",   A}
+{"\$(P)InpUniv8",  "$(EVG):UnivInp8",   B}
+{"\$(P)InpUniv9",  "$(EVG):UnivInp9",   C}
+{"\$(P)InpUniv10", "$(EVG):UnivInp10",  D}
 pattern
 {P, OBJ, Num, CONT}
-{"\$(P)InpRear0",  "$(EVG):RearInp0",   0, "1"}
-{"\$(P)InpRear1",  "$(EVG):RearInp1",   1, "1"}
-{"\$(P)InpRear2",  "$(EVG):RearInp2",   2, "1"}
-{"\$(P)InpRear3",  "$(EVG):RearInp3",   3, "1"}
-{"\$(P)InpRear4",  "$(EVG):RearInp4",   4, "1"}
-{"\$(P)InpRear5",  "$(EVG):RearInp5",   5, "1"}
-{"\$(P)InpRear6",  "$(EVG):RearInp6",   6, "1"}
-{"\$(P)InpRear7",  "$(EVG):RearInp7",   7, "1"}
-{"\$(P)InpRear8",  "$(EVG):RearInp8",   8, "1"}
-{"\$(P)InpRear9",  "$(EVG):RearInp9",   9, "1"}
+{"\$(P)InpUniv11", "$(EVG):UnivInp11",  0, "1"}
+{"\$(P)InpUniv12", "$(EVG):UnivInp12",  1, "1"}
+{"\$(P)InpUniv13", "$(EVG):UnivInp13",  2, "1"}
+{"\$(P)InpUniv14", "$(EVG):UnivInp14",  3, "1"}
+{"\$(P)InpUniv15", "$(EVG):UnivInp15",  4, "1"}
+{"\$(P)InpRear0",  "$(EVG):RearInp0",   5, "1"}
+{"\$(P)InpRear1",  "$(EVG):RearInp1",   0, "2"}
+{"\$(P)InpRear2",  "$(EVG):RearInp2",   1, "2"}
+{"\$(P)InpRear3",  "$(EVG):RearInp3",   2, "2"}
+{"\$(P)InpRear4",  "$(EVG):RearInp4",   3, "2"}
+{"\$(P)InpRear5",  "$(EVG):RearInp5",   4, "2"}
+{"\$(P)InpRear6",  "$(EVG):RearInp6",   5, "2"}
+{"\$(P)InpRear7",  "$(EVG):RearInp7",   6, "2"}
+{"\$(P)InpRear8",  "$(EVG):RearInp8",   7, "2"}
+{"\$(P)InpRear9",  "$(EVG):RearInp9",   8, "2"}
+{"\$(P)InpRear10",  "$(EVG):RearInp10",   9, "2"}
+{"\$(P)InpRear11",  "$(EVG):RearInp11",   A, "2"}
+{"\$(P)InpRear12",  "$(EVG):RearInp12",   B, "2"}
+{"\$(P)InpRear13",  "$(EVG):RearInp13",   C, "2"}
+{"\$(P)InpRear14",  "$(EVG):RearInp14",   D, "2"}
+{"\$(P)InpRear15",  "$(EVG):RearInp15",   E, "2"}
 }
 
-file "evgMrm-vme300.db"
+file "evgMrm.db"
 {
 {P="\$(P)", SOFTEVT="\$(P)SoftEvt", OBJ="$(EVG)", EVG="$(EVG)"}
 }
@@ -99,7 +115,7 @@ file "evgSoftSeq.template"
 {"\$(P)SoftSeq1", $(EVG), 1, 2047}
 }
 
-file "evgTrigEvt-vme300.db"
+file "evgTrigEvt.db"
 {pattern
 {P, OBJ, EVG, trigEvtNum}
 {"\$(P)TrigEvt0", "$(EVG):TrigEvt0", $(EVG), 0}

--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -25,6 +25,7 @@ DB += evr-mtca-300u.db
 
 ifdef BASE_3_15
 DB += evr-mtca-300u.uv.db
+DB += evr-vme-300.db
 endif
 
 ifneq ($(DEVIOCSTATS),)

--- a/evrMrmApp/Db/evr-vme-300.substitutions
+++ b/evrMrmApp/Db/evr-vme-300.substitutions
@@ -1,0 +1,488 @@
+# Record set for a universal EVR (tested with VME-300 card)
+#
+# Macros:
+# P = Prefix
+# EVR = Card name (same as mrmEvrSetupPCI())
+# FEVT = Event link frequency (default 124.916 MHz)
+# Naming-agnostic
+# ===============
+global {s=""}
+
+file "mrmevrbase.template"
+{
+{P="\$(P)", OBJ="$(EVR)", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
+}
+file "databuftx.db"
+{pattern
+{P, OBJ, PROTO, s}
+{"\$(P)", "$(EVR):BUFTX", 1, "-"}
+}
+
+file "evrSoftEvt.template"
+{
+{P="\$(P)", OBJ="$(EVR)"}
+}
+
+file "databuftxCtrl.db"
+{pattern
+{P, OBJ}
+{"\$(P)", "$(EVR):BUFTX"}
+}
+
+file "mrmevrbufrx.db"
+{pattern
+{P, OBJ, PROTO, s}
+{"\$(P)", "$(EVR):BUFRX", "0xff00", "-"}
+}
+
+file "mrmSoftSeq.template"
+{pattern
+{P, EVG, seqNum, NELM}
+{"\$(P)SoftSeq0", $(EVR), 0, 2047}
+}
+
+file "evrSoftSeq.template"
+{pattern
+{P, EVG, seqNum, NELM }
+{"\$(P)SoftSeq0", $(EVR), 0, 2047}
+}
+
+file "sfp.db"
+{
+{P="\$(P)SFP", OBJ="$(EVR):SFP"}
+}
+
+file "mrmevrdc.template"
+{
+{P="\$(P)DC", OBJ="$(EVR)"}
+}
+
+file "evrmap.db"
+{pattern
+{NAME, OBJ, func, EVT}
+{"\$(P)EvtBlink0-SP", "$(EVR)", Blink, 15}
+{"\$(P)EvtBlink1-SP", "$(EVR)", Blink, 0}
+{"\$(P)EvtResetPS-SP","$(EVR)", "Reset PS", 123}
+}
+
+file "evrevent.db"
+{pattern
+{EN, OBJ, CODE, EVNT}
+{"\$(P)Pps",  "$(EVR)", 0x7d, 125}
+{"\$(P)EvtA", "$(EVR)", 10, 10}
+{"\$(P)EvtB", "$(EVR)", 11, 11}
+{"\$(P)EvtC", "$(EVR)", 12, 12}
+{"\$(P)EvtD", "$(EVR)", 13, 13}
+{"\$(P)EvtE", "$(EVR)", 14, 14}
+{"\$(P)EvtF", "$(EVR)", 15, 15}
+{"\$(P)EvtG", "$(EVR)", 16, 16}
+{"\$(P)EvtH", "$(EVR)", 17, 17}
+}
+
+file "evrscale.db"
+{pattern
+{IDX, P, SN, OBJ, MAX}
+{0, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{1, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{2, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{3, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{4, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{5, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{6, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+{7, "\$(P)", "\$(P)PS$(IDX)", "$(EVR):PS$(IDX)", "0xffffffff"}
+}
+
+file "mrmevrout.db"
+{pattern
+{ON, OBJ, DESC}
+{"\$(P)OutInt", "$(EVR):Int", "Internal"}
+{"\$(P)OutFPUV00", "$(EVR):FrontUnivOut0", "FPUV 0"}
+{"\$(P)OutFPUV01", "$(EVR):FrontUnivOut1", "FPUV 1"}
+{"\$(P)OutFPUV02", "$(EVR):FrontUnivOut2", "FPUV 2"}
+{"\$(P)OutFPUV03", "$(EVR):FrontUnivOut3", "FPUV 3"}
+{"\$(P)OutFPUV04", "$(EVR):FrontUnivOut4", "FPUV 0"}
+{"\$(P)OutFPUV05", "$(EVR):FrontUnivOut5", "FPUV 5"}
+{"\$(P)OutFPUV06", "$(EVR):FrontUnivOut6", "FPUV 6 (GTX)"}
+{"\$(P)OutFPUV07", "$(EVR):FrontUnivOut7", "FPUV 7 (GTX)"}
+{"\$(P)OutFPCML00", "$(EVR):FrontUnivOut8", "FP CML 0 (GTX)"}
+{"\$(P)OutFPCML01", "$(EVR):FrontUnivOut9", "FP CML 1 (GTX)"}
+{"\$(P)OutTBUV00", "$(EVR):RearUniv0", "TBUV 0"}
+{"\$(P)OutTBUV01", "$(EVR):RearUniv1", "TBUV 1"}
+{"\$(P)OutTBUV02", "$(EVR):RearUniv2", "TBUV 2"}
+{"\$(P)OutTBUV03", "$(EVR):RearUniv3", "TBUV 3"}
+{"\$(P)OutTBUV04", "$(EVR):RearUniv4", "TBUV 4"}
+{"\$(P)OutTBUV05", "$(EVR):RearUniv5", "TBUV 5"}
+{"\$(P)OutTBUV06", "$(EVR):RearUniv6", "TBUV 6"}
+{"\$(P)OutTBUV07", "$(EVR):RearUniv7", "TBUV 7"}
+{"\$(P)OutTBUV08", "$(EVR):RearUniv8", "TBUV 8"}
+{"\$(P)OutTBUV09", "$(EVR):RearUniv9", "TBUV 9"}
+{"\$(P)OutTBUV10", "$(EVR):RearUniv10", "TBUV 10"}
+{"\$(P)OutTBUV11", "$(EVR):RearUniv11", "TBUV 11"}
+{"\$(P)OutTBUV12", "$(EVR):RearUniv12", "TBUV 12"}
+{"\$(P)OutTBUV13", "$(EVR):RearUniv13", "TBUV 13"}
+{"\$(P)OutTBUV14", "$(EVR):RearUniv14", "TBUV 14"}
+{"\$(P)OutTBUV15", "$(EVR):RearUniv15", "TBUV 15"}
+}
+
+file "mrmevroutint.db"
+{{
+    ON="\$(P)OutInt", OBJ="$(EVR)"
+}}
+
+file "evrcml.db"
+{pattern
+{P, ON, OBJ, NBIT, MAX}
+{"\$(P)", "\$(P)OutFPUV06", "$(EVR):CML0", 40, 81880}
+{"\$(P)", "\$(P)OutFPUV07", "$(EVR):CML1", 40, 81880}
+{"\$(P)", "\$(P)OutFPCML00", "$(EVR):CML2", 40, 81880}
+{"\$(P)", "\$(P)OutFPCML01", "$(EVR):CML3", 40, 81880}
+}
+
+# Pulse generators w/o a prescaler set NOPS=1
+file "evrpulser.db"
+{pattern
+{PID, P, PN, OBJ, DMAX, WMAX, PMAX, NOPS}
+{0, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{5, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{6, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{7, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{8, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{9, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{10,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{11,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{12,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{13,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{14,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{15,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{16,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{17,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{18,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{19,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{20,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{21,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{22,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{23,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+# gate generators
+{28,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{29,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{30,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+{31,"\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "1", 1}
+}
+
+# Default to 3 possible trigger mappings per pulser
+file "evrpulsermap.db"
+{pattern
+{PID, NAME, OBJ, F, EVT}
+{0, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{1, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{2, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{3, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{4, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{5, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{6, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{7, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{8, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{9, "\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{10,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{11,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{12,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{13,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{14,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{15,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{16,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{16,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{16,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{17,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{17,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{17,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{18,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{18,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{18,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{19,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{19,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{19,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{20,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{20,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{20,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{21,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{21,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{21,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{22,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{22,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{22,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{23,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{23,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{23,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{28,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{28,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{29,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{30,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{31,"\$(P)DlyGen$(PID)EvtTrig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{0, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{1, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{2, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{3, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{4, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{5, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{6, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{7, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{8, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{9, "\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{10,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{11,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{12,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{13,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{14,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{15,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{16,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{16,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{16,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{17,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{17,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{17,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{18,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{18,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{18,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{19,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{19,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{19,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{20,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{20,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{20,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{21,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{21,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{21,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{22,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{22,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{22,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{23,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{23,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{23,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{28,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{29,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{30,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet0-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet1-SP", "$(EVR):Pul$(PID)", Set, 0}
+{31,"\$(P)DlyGen$(PID)EvtSet2-SP", "$(EVR):Pul$(PID)", Set, 0}
+
+{0, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{0, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{1, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{2, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{3, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{4, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{5, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{6, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{7, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{8, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{9, "\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{10,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{11,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{12,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{13,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{14,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{15,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{16,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{16,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{16,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{17,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{17,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{17,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{18,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{18,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{18,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{19,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{19,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{19,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{20,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{20,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{20,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{21,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{21,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{21,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{22,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{22,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{22,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{23,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{23,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{23,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+
+# gate generators mappings
+{28,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{28,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{29,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{30,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset0-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset1-SP", "$(EVR):Pul$(PID)", Reset, 0}
+{31,"\$(P)DlyGen$(PID)EvtReset2-SP", "$(EVR):Pul$(PID)", Reset, 0}
+
+
+}
+
+# pulser masking controls
+file "evrdcpulser.template"
+{pattern
+{PID, P, PN, OBJ}
+{0,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{1,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{2,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{3,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{4,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{5,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{6,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{7,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{8,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{9,  "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{10, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{11, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{12, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{13, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{14, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{15, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{16, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{17, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{18, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{19, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{20, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{21, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{22, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+{23, "\$(P)", "\$(P)DlyGen$(PID)", "$(EVR):Pul$(PID)"}
+}
+
+file "evrin.db"
+{pattern
+{IN, OBJ, DESC}
+{"\$(P)In0"     , "$(EVR):FPIn0" , "IN0 (TTL)"}
+{"\$(P)In1"     , "$(EVR):FPIn1" , "IN1 (TTL)"}
+}
+
+file "mrmevrdlymodule.template"
+{pattern
+{SLOT, P, OBJ}
+{0, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+{1, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+{2, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+{3, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+}


### PR DESCRIPTION
1: Added substitution files for the EVM-VME-300 and EVR-VME-300
2: Because the VME boards support rear transition boards, it has more I/O options. I expanded the selection records for dbus, trigEvt and Pps Selection. I have a mechanism to prevent selecting from multiple sources. If one is selected, the others are changed automatically to "OFF"