### PR TITLE
Added the feature of setting a delay target for an EVM

### DIFF
--- a/evgMrmApp/Db/evm-fct.template
+++ b/evgMrmApp/Db/evm-fct.template
@@ -155,3 +155,56 @@ record(longin, "$(P)ID-I") {
   field(INP, "@OBJ=$(OBJ), PROP=TopoID")
   field(SCAN, "1 second")
 }
+
+# Delay compensation at the EVM level
+record(bo, "$(P)DC-Ena-Sel") {
+  field(DESC, "Apply DC correction")
+  field(DTYP, "Obj Prop bool")
+  field(OUT, "@OBJ=$(OBJ), PROP=DCUpMode")
+  field(ZNAM, "Disable")
+  field(ONAM, "Enable")
+  field(PINI, "YES")
+  field(PHAS, "1") # after Tgt-SP
+  field(FLNK, "$(P)DC-Ena-RB")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(bi, "$(P)DC-Ena-RB") {
+  field(DESC, "Apply DC correction")
+  field(DTYP, "Obj Prop bool")
+  field(INP, "@OBJ=$(OBJ), PROP=DCUpMode")
+  field(ZNAM, "Disable")
+  field(ONAM, "Enable")
+}
+
+record(ao, "$(P)DC-Tgt-SP") {
+  field(DESC, "Desired total delay")
+  field(DTYP, "Obj Prop double")
+  field(OUT, "@OBJ=$(OBJ), PROP=DCUpTarget")
+  field(EGU, "ns")
+  # a too small value will cause glitches and dropped events.
+  # so we pick a conservative default suitable for the slowest 50MHz clock
+  field(VAL, "110")
+  field(PREC, "3")
+  field(PINI, "YES")
+  field(FLNK, "$(P)DC-Tgt-RB")
+  info(autosaveFields_pass0, "VAL EGU ESLO HOPR LOPR DRVH DRVL PREC")
+}
+
+record(ai, "$(P)DC-Tgt-RB") {
+  field(DESC, "Desired total delay")
+  field(DTYP, "Obj Prop double")
+  field(INP, "@OBJ=$(OBJ), PROP=DCUpTarget")
+  field(EGU, "ns")
+  field(PREC, "3")
+  info(autosaveFields_pass0, "EGU ESLO HOPR LOPR PREC")
+}
+
+record(calc, "$(P)Msrd$(s=:)Total-I") {
+  field(SCAN, "1 second")
+  field(CALC, "A+B")
+  field(INPA, "$(P)Msrd$(s=:)Up-I NPP")
+  field(INPB, "$(P)Msrd$(s=:)FIFO-I NPP")
+  field(EGU, "ns")
+  field(PREC, "3")
+}

--- a/evgMrmApp/src/fct.cpp
+++ b/evgMrmApp/src/fct.cpp
@@ -15,6 +15,8 @@
 #define U32_UpDCValue 0x10
 #define U32_FIFODCValue 0x14
 #define U32_IntDCValue 0x18
+#define U32_UpDCTarget 0x1C
+#define U32_UpDCMode 0x24
 #define U32_TOPID 0x2c
 #define U32_PortNDCValue(N) (0x40 +(N)*4)
 
@@ -59,6 +61,33 @@ double FCT::dcInternal() const
     return double(READ32(base, IntDCValue))/65536.0*period;
 }
 
+bool FCT::getDcUpMode() const
+{
+    return bool(READ32(base, UpDCMode));
+}
+
+void FCT::setDcUpMode(bool ena)
+{
+    if (ena){
+        WRITE32(base, UpDCMode,0x1);
+    }else{
+        WRITE32(base, UpDCMode,0x0);
+    }
+}
+
+double FCT::getDcUpTarget() const
+{
+    double period=1e3/evg->getFrequency(); // in nanoseconds
+    return double(READ32(base, UpDCTarget))/65536.0*period;
+}
+
+void FCT::setDcUpTarget(double target)
+{
+    double period=1e3/evg->getFrequency(); // in nanoseconds
+    epicsUInt32 tgt = epicsUInt32(target/period*65536.0);
+    WRITE32(base, UpDCTarget,tgt);
+}
+
 epicsUInt32 FCT::topoId() const
 {
     return READ32(base, TOPID);
@@ -75,6 +104,8 @@ OBJECT_BEGIN(FCT)
     OBJECT_PROP1("DCUpstream", &FCT::dcUpstream);
     OBJECT_PROP1("DCFIFO", &FCT::dcFIFO);
     OBJECT_PROP1("DCInternal", &FCT::dcInternal);
+    OBJECT_PROP2("DCUpMode", &FCT::getDcUpMode , &FCT::setDcUpMode);
+    OBJECT_PROP2("DCUpTarget", &FCT::getDcUpTarget, &FCT::setDcUpTarget);
     OBJECT_PROP1("TopoID", &FCT::topoId);
     OBJECT_PROP1("DCPort1", &FCT::dcPort<0>);
     OBJECT_PROP1("DCPort2", &FCT::dcPort<1>);

--- a/evgMrmApp/src/fct.h
+++ b/evgMrmApp/src/fct.h
@@ -32,6 +32,10 @@ public:
     double dcUpstream() const;
     double dcFIFO() const;
     double dcInternal() const;
+    bool getDcUpMode() const;
+    void setDcUpMode(bool ena);
+    double getDcUpTarget() const;
+    void setDcUpTarget(double target);
 
     epicsUInt32 topoId() const;
 


### PR DESCRIPTION
This feature allows us to set a target delay of an EVM and it will adjust its FIFO depth to compensate the delay. This allows people to have a partial delay compensation for devices with embedded EVRs that do not support delay compensation. 