### PR TITLE
mrf kernel driver updates for kernels 6.3+

### DIFF
--- a/mrmShared/linux/.gitignore
+++ b/mrmShared/linux/.gitignore
@@ -7,3 +7,4 @@ modules.order
 .tmp_versions
 ifc
 ppmac
+*.mod

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -123,7 +123,11 @@ int mrf_mmap_physical(struct uio_info *info, struct vm_area_struct *vma)
         return -EINVAL;
     }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
+    vm_flags_set(vma, VM_IO | VM_RESERVED);
+#else
     vma->vm_flags |= VM_IO | VM_RESERVED;
+#endif
     vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 
     return remap_pfn_range(vma,


### PR DESCRIPTION
From Linux kernel version 6.3 onward the `vma->vm_flags` are private; `vm_flags_set()` should be used instead.

After compilation I see `mrf.mod` that was not in `.gitignore`; added.

Tested on a local crate running Linux kernel version 6.7.