### PR TITLE
Adding the hardware Mxc reset function for each input

### DIFF
--- a/evgMrmApp/Db/evgInput.db
+++ b/evgMrmApp/Db/evgInput.db
@@ -30,3 +30,22 @@ record(ai, "$(P)FPMask-RB") {
   field(DTYP, "Obj Prop uint32")
   field(INP , "@OBJ=$(OBJ), PROP=FPMASK")
 }
+
+record(bo, "$(P)EnaMxcr-Sel") {
+  field(DESC, "Enable Hardware Mxc Reset")
+  field(DTYP, "Obj Prop bool")
+  field(OUT , "@OBJ=$(OBJ), PROP=Hw Reset MXC")
+  field(ZNAM, "Disabled")
+  field(ONAM, "Enabled")
+  field(FLNK, "$(P)EnaIrq-RB")
+  info(autosaveFields_pass0, "VAL")
+}
+
+record(bi, "$(P)EnaMxcr-RB") {
+  field(DESC, "Enable Hardware Mxc Reset")
+  field(DTYP, "Obj Prop bool")
+  field(INP , "@OBJ=$(OBJ), PROP=Hw Reset MXC")
+  field(ZNAM, "Disabled")
+  field(ONAM, "Enabled")
+}
+

--- a/evgMrmApp/src/evg.cpp
+++ b/evgMrmApp/src/evg.cpp
@@ -30,7 +30,7 @@ OBJECT_BEGIN(evgInput) {
     OBJECT_PROP2("IRQ", &evgInput::getExtIrq, &evgInput::setExtIrq);    
     OBJECT_PROP2("FPMASK", &evgInput::getHwMask, &evgInput::setHwMask);
     OBJECT_PROP1("FPMASK", &evgInput::stateChange);
-
+    OBJECT_PROP2("Hw Reset MXC", &evgInput::getMxcReset, &evgInput::setMxcReset);    
 } OBJECT_END(evgInput)
 
 OBJECT_BEGIN(evgMxc) {

--- a/evgMrmApp/src/evgInput.cpp
+++ b/evgMrmApp/src/evgInput.cpp
@@ -92,6 +92,21 @@ evgInput::getDbusMap(epicsUInt16 dbus) const {
     return (map & mask) != 0;
 }
 
+bool
+evgInput::getMxcReset() const
+{
+    bool val;
+    val = (nat_ioread32(m_pInReg) & EVG_INP_MXCR_ENA) >> EVG_INP_MXCR_ENA_shift;
+    return val;
+}
+
+void evgInput::setMxcReset(bool ena)
+{
+    epicsUInt32 src = ena;
+    epicsUInt32 inReg=nat_ioread32(m_pInReg) & ~(EVG_INP_MXCR_ENA);
+    nat_iowrite32(m_pInReg, inReg | (src<<EVG_INP_MXCR_ENA_shift));
+}
+
 void
 evgInput::setSeqTrigMap(epicsUInt32 seqTrigMap) {
     if(seqTrigMap > 3)
@@ -100,7 +115,7 @@ evgInput::setSeqTrigMap(epicsUInt32 seqTrigMap) {
     //Read-Modify-Write
     epicsUInt32 map = nat_ioread32(m_pInReg);
 
-    map = map & 0xffff00ff;
+    map = map & 0xfffff0ff;
     map = map | (seqTrigMap << 8);
 
     nat_iowrite32(m_pInReg, map);
@@ -109,7 +124,7 @@ evgInput::setSeqTrigMap(epicsUInt32 seqTrigMap) {
 epicsUInt32
 evgInput::getSeqTrigMap() const {
     epicsUInt32 map = nat_ioread32(m_pInReg);
-    map = map & 0x0000ff00;
+    map = map & 0x00000f00;
     map = map >> 8;
     return map;
 }

--- a/evgMrmApp/src/evgInput.h
+++ b/evgMrmApp/src/evgInput.h
@@ -42,6 +42,9 @@ public:
     void setSeqTrigMap(epicsUInt32);
     epicsUInt32 getSeqTrigMap() const;
 
+    void setMxcReset(bool);
+    bool getMxcReset() const;
+
     void setTrigEvtMap(epicsUInt16, bool);
     bool getTrigEvtMap(epicsUInt16) const;
 

--- a/evgMrmApp/src/evgRegMap.h
+++ b/evgMrmApp/src/evgRegMap.h
@@ -303,6 +303,8 @@
 #define  EVG_INP_FP_ENA_shift   24 
 #define  EVG_INP_FP_MASK        0xF0000000
 #define  EVG_INP_FP_MASK_shift  28
+#define  EVG_INP_MXCR_ENA       0x00008000
+#define  EVG_INP_MXCR_ENA_shift 15
 
 #ifndef  EVG_CONSTANTS
 #define  EVG_CONSTANTS


### PR DESCRIPTION
This feature allows people to use an external signal to reset the multplexed counters. 
This feature is only functional with firmware version 207.11. The earlier FW had a bug.