### PR TITLE
Add the EVM frac Synth reset function

### DIFF
--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -385,3 +385,9 @@ record(mbbi, "$(P)TSGen-RB") {
   field(ONVL, "0x1")
   field(TWVL, "0x2")
 }
+
+record(bo,"$(P)ResetFracSynth-Cmd" ) {
+    field( DTYP, "Obj Prop command")
+    field( OUT , "@OBJ=$(OBJ), PROP=Reset Frac Synth")
+    field( DESC, "Reset")
+}

--- a/evgMrmApp/src/evg.cpp
+++ b/evgMrmApp/src/evg.cpp
@@ -84,4 +84,5 @@ OBJECT_BEGIN(evgMrm) {
     OBJECT_PROP1("Frequency",   &evgMrm::getFrequency);
     OBJECT_PROP1("PLL Lock Status", &evgMrm::pllLocked);
     OBJECT_PROP2("PLL Bandwidth",   &evgMrm::getPLLBandwidth, &evgMrm::setPLLBandwidth);
+    OBJECT_PROP1("Reset Frac Synth",&evgMrm::resetFracSynth);
 } OBJECT_END(evgMrm)

--- a/evgMrmApp/src/evgMrm.cpp
+++ b/evgMrmApp/src/evgMrm.cpp
@@ -524,6 +524,13 @@ evgMrm::setEvtCode(epicsUInt32 evtCode) {
 }
 
 /**    Access    functions     **/
+void
+evgMrm::resetFracSynth()
+{
+  epicsUInt32 oldControlWord=READ32(m_pReg, FracSynthWord);
+  WRITE32(m_pReg, FracSynthWord, oldControlWord);
+}
+
 
 evgInput*
 evgMrm::getInput(epicsUInt32 inpNum, InputType type) {

--- a/evgMrmApp/src/evgMrm.h
+++ b/evgMrmApp/src/evgMrm.h
@@ -151,6 +151,7 @@ public:
     evgInput* getInput(epicsUInt32, InputType);
     epicsEvent* getTimerEvent();
     const bus_configuration* getBusConfiguration();
+    void resetFracSynth();
 
     CALLBACK                      irqExtInp_cb;
 


### PR DESCRIPTION
If the reference clock has a glitch (a forward shift of phase), the event clock is down and the EVM ends up in a state where it cannot automatically recover the event clock even the PLL status shows fine. To fix this, the FracSynth control word must be rewritten. Writing to that register triggers some low-level reset of the board and the event clock is recovered after that. 

In the current code, writing to the record of the Frac Synth frequency does not result in writing to the control word register, because it checks if the requested frequency value changes. I had to write a different frequency and write back the old value. This is inconvenient and likely to introduce error when I just need a reset. In this commit, I made a dedicated api function and a record to write the same control word value to the register. This is only used for the resetting purpose.