### PR TITLE
adding virtual univ inputs for EVM-VME-300 for EVRU/D event forwarding

### DIFF
--- a/evgMrmApp/src/evgInit.cpp
+++ b/evgMrmApp/src/evgInit.cpp
@@ -72,7 +72,7 @@ static const evgMrm::Config conf_vme_evg_230 = {
 static const evgMrm::Config conf_vme_evm_300 = {
     "VME-EVM-300",
     3,
-    0,
+    16,
     16,
 };
 


### PR DESCRIPTION
Even though the evm-vme-300 does not have physical UNIV I/O channels, it does have the channels logically that can be used as interfaces with the EVRU and EVRD. This commit changes the number of UNIV I/O of vme-300 from 0 to 16.
