### PR TITLE
feat: Fine delay for rear transition board

### DIFF
--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -6,6 +6,7 @@ include $(TOP)/configure/CONFIG
 USR_DBFLAGS += -I$(TOP)/mrmShared/Db
 
 DB += mrmevrout.db
+DB += mrmevroutdly.db
 DB += mrmevrbase.template
 DB += mrmevrdc.template
 DB += mrmevrbufrx.db

--- a/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.uv.substitutions
@@ -499,10 +499,21 @@ file "evrin.db"
 {"\$(P)BPIn7"   , "$(EVR):FPIn31", "BPIN7 (LVDS)"}
 }
 
+# Obsolete: check inside mrmevrdlymodule.template for more info
+# Left for the backward compatibility - use mrmevroutdly.db instead
 file "mrmevrdlymodule.template"
 {pattern
 {SLOT, P, OBJ}
 {0, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
 {1, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+}
 
+file "mrmevroutdly.db"
+{pattern
+{ON, OBJ}
+# FP UNIV
+{"\$(P)OutFPUV0",  "$(EVR):FrontUnivOut0"}
+{"\$(P)OutFPUV1",  "$(EVR):FrontUnivOut1"}
+{"\$(P)OutFPUV2",  "$(EVR):FrontUnivOut2"}
+{"\$(P)OutFPUV3",  "$(EVR):FrontUnivOut3"}
 }

--- a/evrMrmApp/Db/evr-vme-300.substitutions
+++ b/evrMrmApp/Db/evr-vme-300.substitutions
@@ -478,6 +478,8 @@ file "evrin.db"
 {"\$(P)In1"     , "$(EVR):FPIn1" , "IN1 (TTL)"}
 }
 
+# Obsolete: check inside mrmevrdlymodule.template for more info
+# Left for the backward compatibility - use mrmevroutdly.db instead
 file "mrmevrdlymodule.template"
 {pattern
 {SLOT, P, OBJ}
@@ -485,4 +487,34 @@ file "mrmevrdlymodule.template"
 {1, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
 {2, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
 {3, "\$(P)OutFPDly$(SLOT)", "$(EVR)"}
+}
+
+file "mrmevroutdly.db"
+{pattern
+{ON, OBJ}
+# FP UNIV
+{"\$(P)OutFPUV00", "$(EVR):FrontUnivOut0"}
+{"\$(P)OutFPUV01", "$(EVR):FrontUnivOut1"}
+{"\$(P)OutFPUV02", "$(EVR):FrontUnivOut2"}
+{"\$(P)OutFPUV03", "$(EVR):FrontUnivOut3"}
+{"\$(P)OutFPUV04", "$(EVR):FrontUnivOut4"}
+{"\$(P)OutFPUV05", "$(EVR):FrontUnivOut5"}
+{"\$(P)OutFPUV06", "$(EVR):FrontUnivOut6"}
+{"\$(P)OutFPUV07", "$(EVR):FrontUnivOut7"}
+{"\$(P)OutTBUV00", "$(EVR):RearUniv0"}
+{"\$(P)OutTBUV01", "$(EVR):RearUniv1"}
+{"\$(P)OutTBUV02", "$(EVR):RearUniv2"}
+{"\$(P)OutTBUV03", "$(EVR):RearUniv3"}
+{"\$(P)OutTBUV04", "$(EVR):RearUniv4"}
+{"\$(P)OutTBUV05", "$(EVR):RearUniv5"}
+{"\$(P)OutTBUV06", "$(EVR):RearUniv6"}
+{"\$(P)OutTBUV07", "$(EVR):RearUniv7"}
+{"\$(P)OutTBUV08", "$(EVR):RearUniv8"}
+{"\$(P)OutTBUV09", "$(EVR):RearUniv9"}
+{"\$(P)OutTBUV10", "$(EVR):RearUniv10"}
+{"\$(P)OutTBUV11", "$(EVR):RearUniv11"}
+{"\$(P)OutTBUV12", "$(EVR):RearUniv12"}
+{"\$(P)OutTBUV13", "$(EVR):RearUniv13"}
+{"\$(P)OutTBUV14", "$(EVR):RearUniv14"}
+{"\$(P)OutTBUV15", "$(EVR):RearUniv15"}
 }

--- a/evrMrmApp/Db/mrmevrdlymodule.template
+++ b/evrMrmApp/Db/mrmevrdlymodule.template
@@ -1,3 +1,8 @@
+# Deprecated: mrmevrdlymodule.template
+# This template is obsolete and should not be used in new implementations.
+# It will be removed in future versions. Please use evrMrmApp/Db/mrmevrout.db $(ON)FineDelay-SP and $(ON)FineDelay-RB instead.
+# Date of obsolescence: [17/09/2024]
+
 # Delay Module control
 #
 # Macros:

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -523,3 +523,31 @@ record(waveform, "$(ON)Label-I") {
   info(autosaveFields_pass1, "VAL")
   alias("$(ON)User-SP")
 }
+
+# Fine delay
+
+record(ao, "$(ON)FineDelay-SP") {
+  field( DESC, "First delay output")
+  field( DTYP, "Obj Prop double")
+  field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( EGU , "ns")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "8.686")
+  field( LOPR, "0")
+  field( PREC, 2)
+  field( FLNK, "$(ON)FineDelay-RB")
+  info( autosaveFields_pass0, "VAL")
+}
+
+record(ai, "$(ON)FineDelay-RB") {
+  field( DESC, "First delay readback")
+  field( DTYP, "Obj Prop double")
+  field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( HIHI, "8.687")
+  field( LOLO, "-0.001")
+  field( PREC, 2)
+  field( EGU,  "ns")
+}
+
+

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -523,31 +523,3 @@ record(waveform, "$(ON)Label-I") {
   info(autosaveFields_pass1, "VAL")
   alias("$(ON)User-SP")
 }
-
-# Fine delay
-
-record(ao, "$(ON)FineDelay-SP") {
-  field( DESC, "First delay output")
-  field( DTYP, "Obj Prop double")
-  field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
-  field( EGU , "ns")
-  field( PINI, "YES")
-  field( VAL , "0")
-  field( HOPR, "8.686")
-  field( LOPR, "0")
-  field( PREC, 2)
-  field( FLNK, "$(ON)FineDelay-RB")
-  info( autosaveFields_pass0, "VAL")
-}
-
-record(ai, "$(ON)FineDelay-RB") {
-  field( DESC, "First delay readback")
-  field( DTYP, "Obj Prop double")
-  field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
-  field( HIHI, "8.687")
-  field( LOLO, "-0.001")
-  field( PREC, 2)
-  field( EGU,  "ns")
-}
-
-

--- a/evrMrmApp/Db/mrmevroutdly.db
+++ b/evrMrmApp/Db/mrmevroutdly.db
@@ -1,0 +1,28 @@
+# Fine delay adapter for mrmevrout.db - outputs with the fine delay capability
+# This file depreciates the mrmevrdlymodule.template
+
+record(ao, "$(ON)FineDelay-SP") {
+  field( DESC, "Fine delay output")
+  field( DTYP, "Obj Prop double")
+  field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( EGU , "ns")
+  field( PINI, "YES")
+  field( VAL , "0")
+  field( HOPR, "8.686")
+  field( LOPR, "0")
+  field( DRVH, "10")
+  field( DRVL, "0")
+  field( PREC, "2")
+  field( FLNK, "$(ON)FineDelay-RB")
+  info( autosaveFields_pass0, "VAL")
+}
+
+record(ai, "$(ON)FineDelay-RB") {
+  field( DESC, "Fine delay")
+  field( DTYP, "Obj Prop double")
+  field( INP , "@OBJ=$(OBJ), PROP=Fine Delay")
+  field( HIHI, "8.687")
+  field( LOLO, "-0.001")
+  field( PREC, "2")
+  field( EGU,  "ns")
+}

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -236,6 +236,15 @@ public:
     const void *isrLinuxPvt;
 #endif
 
+    //get the pointer of the delay module
+    DelayModule* getDelayModule(int i){
+        if (size_t(i)<delays.size()){
+            return delays[i];
+        }else{
+            return NULL;
+        }
+    }
+
     const Config * const conf;
     volatile unsigned char * const base;
     epicsUInt32 baselen;

--- a/evrMrmApp/src/drvemOutput.cpp
+++ b/evrMrmApp/src/drvemOutput.cpp
@@ -155,6 +155,54 @@ MRMOutput::setSourceInternal()
     }
 }
 
+//Fine delay for UNIV-TTL-DLY on UTB64x board
+void
+MRMOutput::setFineDelay(double val)
+{
+    double period = 1e9/owner->clock(); //clock period in ns
+
+    if(val < 0) val = 0;
+    if(val > period)val = period;
+    epicsUInt32 ticks=roundToUInt(val * 1023.0 / period);
+
+    switch(type) {
+    case OutputInt:
+        break; // will not get here
+    case OutputFP:
+        break;
+    case OutputFPUniv:
+        break;
+    case OutputRB:
+        WRITE32(owner->base, RTMDELAY(N), ticks); break;
+    case OutputBackplane:
+        break;
+    }
+}
+
+double
+MRMOutput::fineDelay() const
+{
+    double period = 1e9/owner->clock(); //clock period in ns
+    double dly_val=0.0;
+    switch(type) {
+    case OutputInt:
+        break; // will not get here
+    case OutputFP:
+        break;
+    case OutputFPUniv:
+        break;
+    case OutputRB:
+        epicsUInt32 ticks;
+        ticks = READ32(owner->base,RTMDELAY(N));
+        dly_val = (ticks*period)/1023.0;
+        break;
+    case OutputBackplane:
+        break;
+    }
+    return dly_val;
+}
+
 OBJECT_BEGIN2(MRMOutput, Output)
   OBJECT_PROP2("Map2", &MRMOutput::source2, &MRMOutput::setSource2);
+  OBJECT_PROP2("Fine Delay", &MRMOutput::fineDelay, &MRMOutput::setFineDelay);
 OBJECT_END(MRMOutput)

--- a/evrMrmApp/src/drvemOutput.cpp
+++ b/evrMrmApp/src/drvemOutput.cpp
@@ -171,6 +171,13 @@ MRMOutput::setFineDelay(double val)
     case OutputFP:
         break;
     case OutputFPUniv:
+        if (owner->getDelayModule(N/2) != NULL){
+          if (N%2 == 0){
+              owner->getDelayModule(N/2)->setDelay0(val);
+          }else{
+              owner->getDelayModule(N/2)->setDelay1(val);
+          }
+        }
         break;
     case OutputRB:
         WRITE32(owner->base, RTMDELAY(N), ticks); break;
@@ -190,6 +197,13 @@ MRMOutput::fineDelay() const
     case OutputFP:
         break;
     case OutputFPUniv:
+        if (owner->getDelayModule(N/2) != NULL){
+            if (N%2 == 0){
+                dly_val = owner->getDelayModule(N/2)->getDelay0();
+            }else{
+                dly_val = owner->getDelayModule(N/2)->getDelay1();
+            }
+        }
         break;
     case OutputRB:
         epicsUInt32 ticks;

--- a/evrMrmApp/src/drvemOutput.h
+++ b/evrMrmApp/src/drvemOutput.h
@@ -42,6 +42,10 @@ public:
   virtual bool enabled() const OVERRIDE FINAL;
   virtual void enable(bool) OVERRIDE FINAL;
 
+  //Fine delay for UNIV-TTL-DLY on UTB64x board
+  virtual void setFineDelay(double);
+  virtual double fineDelay() const;
+
 private:
   EVRMRM * const owner;
   const OutputType type;

--- a/evrMrmApp/src/evrRegMap.h
+++ b/evrMrmApp/src/evrRegMap.h
@@ -388,6 +388,8 @@
 #define U32_SFPEEPROM(N) (U32_SFPEEPROM_base + (N))
 #define U32_SFPDIAG_base 0x8300
 #define U32_SFPDIAG(N) (U32_SFPDIAG_base + (N))
+#define U32_RTMDELAY_base 0x8400
+#define U32_RTMDELAY(N) (U32_RTMDELAY_base + (4*(N)))
 
 #define EVR_REGMAP_SIZE 0x40000 // Total register map size = 256K
 


### PR DESCRIPTION
MRF has a new transition board that supports the delay tuning of daughter cards. With this new board, for a daughter card that has the delay-tuning feature (like the TTL-DLY and PECL-DLY modules), the delay of the transition board channel can be controlled by an register in the EVR board. The previous version of the TB does not support the fine delay tuning even if the daughter card has the delay tuning. 

In this PR, I have 3 commits, for the EVR registers, API functions and EPICS records. The last commit makes the front panel UNIV channels share the same fine-delay tuning interface. 