### PR TITLE
db file update and bug fix

### DIFF
--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -179,9 +179,19 @@ record(mbbo, "$(P)Src2-Sel") {
   field(ZRST, "Off")
   field(ONST, "Front2")
   field(TWST, "Rear0")
+  field(THST, "Univ11")
+  field(FRST, "Univ12")
+  field(FVST, "Univ13")
+  field(SXST, "Univ14")
+  field(SVST, "Univ15")
   field(ZRVL, "0")
   field(ONVL, "1")
   field(TWVL, "2")
+  field(THVL, "4")
+  field(FRVL, "8")
+  field(FVVL, "16")
+  field(SXVL, "32")
+  field(SVVL, "64")
   field(THSV, "INVALID")
   field(FRSV, "INVALID")
   field(FVSV, "INVALID")
@@ -425,6 +435,56 @@ record(bo, "$(P)Src$(s=:)UnivInp10-Sel") {
   field(ONAM, "Set")
   field(OMSL, "closed_loop")
   field(DOL,  "$(P)Src-MbbiDir_.BC CP")
+}
+
+record(bo, "$(P)Src$(s=:)UnivInp11-Sel") {
+  field(DESC, "Front Univ Input11 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp11")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B2 CP")
+}
+
+record(bo, "$(P)Src$(s=:)UnivInp12-Sel") {
+  field(DESC, "Front Univ Input12 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp12")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B3 CP")
+}
+
+record(bo, "$(P)Src$(s=:)UnivInp13-Sel") {
+  field(DESC, "Front Univ Input13 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp13")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B4 CP")
+}
+
+record(bo, "$(P)Src$(s=:)UnivInp14-Sel") {
+  field(DESC, "Front Univ Input14 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp14")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B5 CP")
+}
+
+record(bo, "$(P)Src$(s=:)UnivInp15-Sel") {
+  field(DESC, "Front Univ Input15 on Dbus")
+  field(DTYP, "EVG Dbus")
+  field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp15")
+  field(ZNAM, "Clear")
+  field(ONAM, "Set")
+  field(OMSL, "closed_loop")
+  field(DOL,  "$(P)Src2-MbbiDir_.B6 CP")
 }
 
 record(bo, "$(P)Src$(s=:)RearInp0-Sel") {

--- a/evgMrmApp/Db/evgInput.db
+++ b/evgMrmApp/Db/evgInput.db
@@ -37,7 +37,7 @@ record(bo, "$(P)EnaMxcr-Sel") {
   field(OUT , "@OBJ=$(OBJ), PROP=Hw Reset MXC")
   field(ZNAM, "Disabled")
   field(ONAM, "Enabled")
-  field(FLNK, "$(P)EnaIrq-RB")
+  field(FLNK, "$(P)EnaMxcr-RB")
   info(autosaveFields_pass0, "VAL")
 }
 

--- a/evgMrmApp/Db/evm-mtca-300.uv.substitutions
+++ b/evgMrmApp/Db/evm-mtca-300.uv.substitutions
@@ -37,11 +37,11 @@ file "evgInput.db"
 # The $(Num) are not sequential to avoid breaking historical autosave files
 {"\$(P)InpFront0", "$(EVG):FrontInp0",  0}
 {"\$(P)InpFront1", "$(EVG):FrontInp1",  1}
-{"\$(P)InpFront2", "$(EVG):FrontInp2",  2}
-{"\$(P)InpUniv0",  "$(EVG):UnivInp0",   3}
-{"\$(P)InpUniv1",  "$(EVG):UnivInp1",   4}
-{"\$(P)InpUniv2",  "$(EVG):UnivInp2",   5}
-{"\$(P)InpUniv3",  "$(EVG):UnivInp3",   6}
+{"\$(P)InpUniv0",  "$(EVG):UnivInp0",   2}
+{"\$(P)InpUniv1",  "$(EVG):UnivInp1",   3}
+{"\$(P)InpUniv2",  "$(EVG):UnivInp2",   4}
+{"\$(P)InpUniv3",  "$(EVG):UnivInp3",   5}
+{"\$(P)InpFront2", "$(EVG):FrontInp2",  6}
 {"\$(P)InpUniv4",  "$(EVG):UnivInp4",   7}
 {"\$(P)InpUniv5",  "$(EVG):UnivInp5",   8}
 {"\$(P)InpUniv6",  "$(EVG):UnivInp6",   9}

--- a/evgMrmApp/Db/evm-vme-300.substitutions
+++ b/evgMrmApp/Db/evm-vme-300.substitutions
@@ -37,25 +37,41 @@ file "evgInput.db"
 # The $(Num) are not sequential to avoid breaking historical autosave files
 {"\$(P)InpFront0", "$(EVG):FrontInp0",  0}
 {"\$(P)InpFront1", "$(EVG):FrontInp1",  1}
-{"\$(P)InpFront2", "$(EVG):FrontInp2",  2}
-{"\$(P)InpRear10", "$(EVG):RearInp10",  3}
-{"\$(P)InpRear11", "$(EVG):RearInp11",  4}
-{"\$(P)InpRear12", "$(EVG):RearInp12",  5}
-{"\$(P)InpRear13", "$(EVG):RearInp13",  6}
-{"\$(P)InpRear14", "$(EVG):RearInp14",  7}
-{"\$(P)InpRear15", "$(EVG):RearInp15",  8}
+{"\$(P)InpUniv0",  "$(EVG):UnivInp0",   2}
+{"\$(P)InpUniv1",  "$(EVG):UnivInp1",   3}
+{"\$(P)InpUniv2",  "$(EVG):UnivInp2",   4}
+{"\$(P)InpUniv3",  "$(EVG):UnivInp3",   5}
+{"\$(P)InpFront2", "$(EVG):FrontInp2",  6}
+{"\$(P)InpUniv4",  "$(EVG):UnivInp4",   7}
+{"\$(P)InpUniv5",  "$(EVG):UnivInp5",   8}
+{"\$(P)InpUniv6",  "$(EVG):UnivInp6",   9}
+{"\$(P)InpUniv7",  "$(EVG):UnivInp7",   A}
+{"\$(P)InpUniv8",  "$(EVG):UnivInp8",   B}
+{"\$(P)InpUniv9",  "$(EVG):UnivInp9",   C}
+{"\$(P)InpUniv10", "$(EVG):UnivInp10",  D}
 pattern
 {P, OBJ, Num, CONT}
-{"\$(P)InpRear0",  "$(EVG):RearInp0",   0, "1"}
-{"\$(P)InpRear1",  "$(EVG):RearInp1",   1, "1"}
-{"\$(P)InpRear2",  "$(EVG):RearInp2",   2, "1"}
-{"\$(P)InpRear3",  "$(EVG):RearInp3",   3, "1"}
-{"\$(P)InpRear4",  "$(EVG):RearInp4",   4, "1"}
-{"\$(P)InpRear5",  "$(EVG):RearInp5",   5, "1"}
-{"\$(P)InpRear6",  "$(EVG):RearInp6",   6, "1"}
-{"\$(P)InpRear7",  "$(EVG):RearInp7",   7, "1"}
-{"\$(P)InpRear8",  "$(EVG):RearInp8",   8, "1"}
-{"\$(P)InpRear9",  "$(EVG):RearInp9",   9, "1"}
+{"\$(P)InpUniv11", "$(EVG):UnivInp11",  0, "1"}
+{"\$(P)InpUniv12", "$(EVG):UnivInp12",  1, "1"}
+{"\$(P)InpUniv13", "$(EVG):UnivInp13",  2, "1"}
+{"\$(P)InpUniv14", "$(EVG):UnivInp14",  3, "1"}
+{"\$(P)InpUniv15", "$(EVG):UnivInp15",  4, "1"}
+{"\$(P)InpRear0",  "$(EVG):RearInp0",   5, "1"}
+{"\$(P)InpRear1",  "$(EVG):RearInp1",   0, "2"}
+{"\$(P)InpRear2",  "$(EVG):RearInp2",   1, "2"}
+{"\$(P)InpRear3",  "$(EVG):RearInp3",   2, "2"}
+{"\$(P)InpRear4",  "$(EVG):RearInp4",   3, "2"}
+{"\$(P)InpRear5",  "$(EVG):RearInp5",   4, "2"}
+{"\$(P)InpRear6",  "$(EVG):RearInp6",   5, "2"}
+{"\$(P)InpRear7",  "$(EVG):RearInp7",   6, "2"}
+{"\$(P)InpRear8",  "$(EVG):RearInp8",   7, "2"}
+{"\$(P)InpRear9",  "$(EVG):RearInp9",   8, "2"}
+{"\$(P)InpRear10", "$(EVG):RearInp10",  9, "2"}
+{"\$(P)InpRear11", "$(EVG):RearInp11",  A, "2"}
+{"\$(P)InpRear12", "$(EVG):RearInp12",  B, "2"}
+{"\$(P)InpRear13", "$(EVG):RearInp13",  C, "2"}
+{"\$(P)InpRear14", "$(EVG):RearInp14",  D, "2"}
+{"\$(P)InpRear15", "$(EVG):RearInp15",  E, "2"}
 }
 
 file "evgMrm.db"

--- a/evrMrmApp/Db/evr-vme-300.substitutions
+++ b/evrMrmApp/Db/evr-vme-300.substitutions
@@ -96,32 +96,32 @@ file "mrmevrout.db"
 {pattern
 {ON, OBJ, DESC}
 {"\$(P)OutInt", "$(EVR):Int", "Internal"}
-{"\$(P)OutFPUV00", "$(EVR):FrontUnivOut0", "FPUV 0"}
-{"\$(P)OutFPUV01", "$(EVR):FrontUnivOut1", "FPUV 1"}
-{"\$(P)OutFPUV02", "$(EVR):FrontUnivOut2", "FPUV 2"}
-{"\$(P)OutFPUV03", "$(EVR):FrontUnivOut3", "FPUV 3"}
-{"\$(P)OutFPUV04", "$(EVR):FrontUnivOut4", "FPUV 0"}
-{"\$(P)OutFPUV05", "$(EVR):FrontUnivOut5", "FPUV 5"}
-{"\$(P)OutFPUV06", "$(EVR):FrontUnivOut6", "FPUV 6 (GTX)"}
-{"\$(P)OutFPUV07", "$(EVR):FrontUnivOut7", "FPUV 7 (GTX)"}
-{"\$(P)OutFPCML00", "$(EVR):FrontUnivOut8", "FP CML 0 (GTX)"}
-{"\$(P)OutFPCML01", "$(EVR):FrontUnivOut9", "FP CML 1 (GTX)"}
-{"\$(P)OutTBUV00", "$(EVR):RearUniv0", "TBUV 0"}
-{"\$(P)OutTBUV01", "$(EVR):RearUniv1", "TBUV 1"}
-{"\$(P)OutTBUV02", "$(EVR):RearUniv2", "TBUV 2"}
-{"\$(P)OutTBUV03", "$(EVR):RearUniv3", "TBUV 3"}
-{"\$(P)OutTBUV04", "$(EVR):RearUniv4", "TBUV 4"}
-{"\$(P)OutTBUV05", "$(EVR):RearUniv5", "TBUV 5"}
-{"\$(P)OutTBUV06", "$(EVR):RearUniv6", "TBUV 6"}
-{"\$(P)OutTBUV07", "$(EVR):RearUniv7", "TBUV 7"}
-{"\$(P)OutTBUV08", "$(EVR):RearUniv8", "TBUV 8"}
-{"\$(P)OutTBUV09", "$(EVR):RearUniv9", "TBUV 9"}
-{"\$(P)OutTBUV10", "$(EVR):RearUniv10", "TBUV 10"}
-{"\$(P)OutTBUV11", "$(EVR):RearUniv11", "TBUV 11"}
-{"\$(P)OutTBUV12", "$(EVR):RearUniv12", "TBUV 12"}
-{"\$(P)OutTBUV13", "$(EVR):RearUniv13", "TBUV 13"}
-{"\$(P)OutTBUV14", "$(EVR):RearUniv14", "TBUV 14"}
-{"\$(P)OutTBUV15", "$(EVR):RearUniv15", "TBUV 15"}
+{"\$(P)OutFPUV0", "$(EVR):FrontUnivOut0", "FPUV 0"}
+{"\$(P)OutFPUV1", "$(EVR):FrontUnivOut1", "FPUV 1"}
+{"\$(P)OutFPUV2", "$(EVR):FrontUnivOut2", "FPUV 2"}
+{"\$(P)OutFPUV3", "$(EVR):FrontUnivOut3", "FPUV 3"}
+{"\$(P)OutFPUV4", "$(EVR):FrontUnivOut4", "FPUV 0"}
+{"\$(P)OutFPUV5", "$(EVR):FrontUnivOut5", "FPUV 5"}
+{"\$(P)OutFPUV6", "$(EVR):FrontUnivOut6", "FPUV 6 (GTX)"}
+{"\$(P)OutFPUV7", "$(EVR):FrontUnivOut7", "FPUV 7 (GTX)"}
+{"\$(P)OutFPCML0", "$(EVR):FrontUnivOut8", "FP CML 0 (GTX)"}
+{"\$(P)OutFPCML1", "$(EVR):FrontUnivOut9", "FP CML 1 (GTX)"}
+{"\$(P)OutRear0", "$(EVR):RearUniv0", "Rear 0"}
+{"\$(P)OutRear1", "$(EVR):RearUniv1", "Rear 1"}
+{"\$(P)OutRear2", "$(EVR):RearUniv2", "Rear 2"}
+{"\$(P)OutRear3", "$(EVR):RearUniv3", "Rear 3"}
+{"\$(P)OutRear4", "$(EVR):RearUniv4", "Rear 4"}
+{"\$(P)OutRear5", "$(EVR):RearUniv5", "Rear 5"}
+{"\$(P)OutRear6", "$(EVR):RearUniv6", "Rear 6"}
+{"\$(P)OutRear7", "$(EVR):RearUniv7", "Rear 7"}
+{"\$(P)OutRear8", "$(EVR):RearUniv8", "Rear 8"}
+{"\$(P)OutRear9", "$(EVR):RearUniv9", "Rear 9"}
+{"\$(P)OutRear10", "$(EVR):RearUniv10", "Rear 10"}
+{"\$(P)OutRear11", "$(EVR):RearUniv11", "Rear 11"}
+{"\$(P)OutRear12", "$(EVR):RearUniv12", "Rear 12"}
+{"\$(P)OutRear13", "$(EVR):RearUniv13", "Rear 13"}
+{"\$(P)OutRear14", "$(EVR):RearUniv14", "Rear 14"}
+{"\$(P)OutRear15", "$(EVR):RearUniv15", "Rear 15"}
 }
 
 file "mrmevroutint.db"
@@ -134,8 +134,8 @@ file "evrcml.db"
 {P, ON, OBJ, NBIT, MAX}
 {"\$(P)", "\$(P)OutFPUV06", "$(EVR):CML0", 40, 81880}
 {"\$(P)", "\$(P)OutFPUV07", "$(EVR):CML1", 40, 81880}
-{"\$(P)", "\$(P)OutFPCML00", "$(EVR):CML2", 40, 81880}
-{"\$(P)", "\$(P)OutFPCML01", "$(EVR):CML3", 40, 81880}
+{"\$(P)", "\$(P)OutFPCML0", "$(EVR):CML2", 40, 81880}
+{"\$(P)", "\$(P)OutFPCML1", "$(EVR):CML3", 40, 81880}
 }
 
 # Pulse generators w/o a prescaler set NOPS=1
@@ -493,28 +493,28 @@ file "mrmevroutdly.db"
 {pattern
 {ON, OBJ}
 # FP UNIV
-{"\$(P)OutFPUV00", "$(EVR):FrontUnivOut0"}
-{"\$(P)OutFPUV01", "$(EVR):FrontUnivOut1"}
-{"\$(P)OutFPUV02", "$(EVR):FrontUnivOut2"}
-{"\$(P)OutFPUV03", "$(EVR):FrontUnivOut3"}
-{"\$(P)OutFPUV04", "$(EVR):FrontUnivOut4"}
-{"\$(P)OutFPUV05", "$(EVR):FrontUnivOut5"}
-{"\$(P)OutFPUV06", "$(EVR):FrontUnivOut6"}
-{"\$(P)OutFPUV07", "$(EVR):FrontUnivOut7"}
-{"\$(P)OutTBUV00", "$(EVR):RearUniv0"}
-{"\$(P)OutTBUV01", "$(EVR):RearUniv1"}
-{"\$(P)OutTBUV02", "$(EVR):RearUniv2"}
-{"\$(P)OutTBUV03", "$(EVR):RearUniv3"}
-{"\$(P)OutTBUV04", "$(EVR):RearUniv4"}
-{"\$(P)OutTBUV05", "$(EVR):RearUniv5"}
-{"\$(P)OutTBUV06", "$(EVR):RearUniv6"}
-{"\$(P)OutTBUV07", "$(EVR):RearUniv7"}
-{"\$(P)OutTBUV08", "$(EVR):RearUniv8"}
-{"\$(P)OutTBUV09", "$(EVR):RearUniv9"}
-{"\$(P)OutTBUV10", "$(EVR):RearUniv10"}
-{"\$(P)OutTBUV11", "$(EVR):RearUniv11"}
-{"\$(P)OutTBUV12", "$(EVR):RearUniv12"}
-{"\$(P)OutTBUV13", "$(EVR):RearUniv13"}
-{"\$(P)OutTBUV14", "$(EVR):RearUniv14"}
-{"\$(P)OutTBUV15", "$(EVR):RearUniv15"}
+{"\$(P)OutFPUV0", "$(EVR):FrontUnivOut0"}
+{"\$(P)OutFPUV1", "$(EVR):FrontUnivOut1"}
+{"\$(P)OutFPUV2", "$(EVR):FrontUnivOut2"}
+{"\$(P)OutFPUV3", "$(EVR):FrontUnivOut3"}
+{"\$(P)OutFPUV4", "$(EVR):FrontUnivOut4"}
+{"\$(P)OutFPUV5", "$(EVR):FrontUnivOut5"}
+{"\$(P)OutFPUV6", "$(EVR):FrontUnivOut6"}
+{"\$(P)OutFPUV7", "$(EVR):FrontUnivOut7"}
+{"\$(P)OutRear0", "$(EVR):RearUniv0"}
+{"\$(P)OutRear1", "$(EVR):RearUniv1"}
+{"\$(P)OutRear2", "$(EVR):RearUniv2"}
+{"\$(P)OutRear3", "$(EVR):RearUniv3"}
+{"\$(P)OutRear4", "$(EVR):RearUniv4"}
+{"\$(P)OutRear5", "$(EVR):RearUniv5"}
+{"\$(P)OutRear6", "$(EVR):RearUniv6"}
+{"\$(P)OutRear7", "$(EVR):RearUniv7"}
+{"\$(P)OutRear8", "$(EVR):RearUniv8"}
+{"\$(P)OutRear9", "$(EVR):RearUniv9"}
+{"\$(P)OutRear10", "$(EVR):RearUniv10"}
+{"\$(P)OutRear11", "$(EVR):RearUniv11"}
+{"\$(P)OutRear12", "$(EVR):RearUniv12"}
+{"\$(P)OutRear13", "$(EVR):RearUniv13"}
+{"\$(P)OutRear14", "$(EVR):RearUniv14"}
+{"\$(P)OutRear15", "$(EVR):RearUniv15"}
 }


### PR DESCRIPTION
Updates for consistency:
1: In the evr-vme-300 substitution file, for the transition board output records, TBUV is changed to RBUV because the objects in the drivers are like RearInput.
2: Added Univ11-15 to the DBus source selection, so that all Univ inputs can be used. Mainly for EVRU and EVRD interface

Bug fix:
1: Fixed the FLNK filed of the Mxc reset enable for hardware input channels
2: Fixed the evm-vme-300 substitution file regarding the bit assignment for the 1 Pps source.