### PR TITLE
fix: Add mbbi record for evg Dbus source sel. Fix the EVR record name for CML

### DIFF
--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -293,8 +293,20 @@ record(mbbo, "$(P)Map-Sel") {
 #
 record(mbbiDirect, "$(P)Src-MbbiDir_") {
   field(ASG, "private")
-  field(DESC, "EVG Trig Evt Trig")
+  field(DESC, "EVG Dbus source")
   field(INP,  "$(P)Src-Sel.RVAL CP")
+}
+
+record(mbbiDirect, "$(P)Src1-MbbiDir_") {
+  field(ASG, "private")
+  field(DESC, "EVG Dbus source 1")
+  field(INP,  "$(P)Src1-Sel.RVAL CP")
+}
+
+record(mbbiDirect, "$(P)Src2-MbbiDir_") {
+  field(ASG, "private")
+  field(DESC, "EVG Dbus source 2")
+  field(INP,  "$(P)Src2-Sel.RVAL CP")
 }
 
 record(bo, "$(P)Src$(s=:)FrontInp0-Sel") {

--- a/evrMrmApp/Db/evr-vme-300.substitutions
+++ b/evrMrmApp/Db/evr-vme-300.substitutions
@@ -132,8 +132,8 @@ file "mrmevroutint.db"
 file "evrcml.db"
 {pattern
 {P, ON, OBJ, NBIT, MAX}
-{"\$(P)", "\$(P)OutFPUV06", "$(EVR):CML0", 40, 81880}
-{"\$(P)", "\$(P)OutFPUV07", "$(EVR):CML1", 40, 81880}
+{"\$(P)", "\$(P)OutFPUV6", "$(EVR):CML0", 40, 81880}
+{"\$(P)", "\$(P)OutFPUV7", "$(EVR):CML1", 40, 81880}
 {"\$(P)", "\$(P)OutFPCML0", "$(EVR):CML2", 40, 81880}
 {"\$(P)", "\$(P)OutFPCML1", "$(EVR):CML3", 40, 81880}
 }


### PR DESCRIPTION
Fixing two bugs discovered during the screen development:
1: The extra two dbus sel records are missing the associated mbbi record. Added them.
2: For the CML records, the name of the associated output records needs an update: FPUV06 to FPUV6, FPUV07 to FPUV7.