### PR TITLE
Fix the pv name in the dbus subscreen after the refactor of Omsl-Fout

### DIFF
--- a/evrMrmApp/Db/evr-vme-300.substitutions
+++ b/evrMrmApp/Db/evr-vme-300.substitutions
@@ -100,7 +100,7 @@ file "mrmevrout.db"
 {"\$(P)OutFPUV1", "$(EVR):FrontUnivOut1", "FPUV 1"}
 {"\$(P)OutFPUV2", "$(EVR):FrontUnivOut2", "FPUV 2"}
 {"\$(P)OutFPUV3", "$(EVR):FrontUnivOut3", "FPUV 3"}
-{"\$(P)OutFPUV4", "$(EVR):FrontUnivOut4", "FPUV 0"}
+{"\$(P)OutFPUV4", "$(EVR):FrontUnivOut4", "FPUV 4"}
 {"\$(P)OutFPUV5", "$(EVR):FrontUnivOut5", "FPUV 5"}
 {"\$(P)OutFPUV6", "$(EVR):FrontUnivOut6", "FPUV 6 (GTX)"}
 {"\$(P)OutFPUV7", "$(EVR):FrontUnivOut7", "FPUV 7 (GTX)"}

--- a/opi/bob/evg/_evg_dbus.bob
+++ b/opi/bob/evg/_evg_dbus.bob
@@ -48,7 +48,7 @@
   </widget>
   <widget type="bool_button" version="2.0.0">
     <name>Boolean Button</name>
-    <pv_name>$(P):Dbus$(N)Omsl-FOut</pv_name>
+    <pv_name>$(P):Dbus$(N)Omsl-Sel</pv_name>
     <x>334</x>
     <height>20</height>
     <off_label>supervisory</off_label>

--- a/opi/bob/evr/evr-vme-300.bob
+++ b/opi/bob/evr/evr-vme-300.bob
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Saved on 2024-10-15 16:19:13 by rhong-->
+<!--Saved on 2024-10-17 16:40:30 by rhong-->
 <display version="2.0.0">
   <name>$(TITLE)</name>
   <width>1920</width>
@@ -14,11 +14,11 @@
     <height>1032</height>
     <style>3</style>
     <foreground_color>
-      <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+      <color name="Header_2_ForeGround" red="255" green="255" blue="255">
       </color>
     </foreground_color>
     <line_color>
-      <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+      <color name="Header_2_ForeGround" red="255" green="255" blue="255">
       </color>
     </line_color>
     <transparent>true</transparent>
@@ -67,7 +67,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -1451,7 +1451,6 @@ $(pv_value)</tooltip>
           <color name="Group_Background" red="240" green="240" blue="240">
           </color>
         </background_color>
-        <active_tab>4</active_tab>
       </widget>
     </widget>
     <widget type="textentry" version="3.0.0">
@@ -1462,11 +1461,11 @@ $(pv_value)</tooltip>
       <width>542</width>
       <height>25</height>
       <foreground_color>
-        <color name="Read_Foreground" red="0" green="0" blue="0">
+        <color name="Read_Foreground" red="0" green="255" blue="0">
         </color>
       </foreground_color>
       <background_color>
-        <color name="Read_Background" red="255" green="255" blue="255">
+        <color name="Read_Background" red="120" green="120" blue="120">
         </color>
       </background_color>
       <format>6</format>
@@ -1489,7 +1488,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -2326,7 +2325,6 @@ $(pv_value)</tooltip>
         <y>5</y>
         <width>799</width>
         <height>443</height>
-        <active_tab>2</active_tab>
         <tooltip>
       </tooltip>
       </widget>
@@ -2343,7 +2341,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -2364,7 +2362,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2382,7 +2380,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2400,7 +2398,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2418,7 +2416,7 @@ $(pv_value)</tooltip>
         <width>61</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2438,7 +2436,7 @@ $(pv_value)</tooltip>
         <width>61</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2458,7 +2456,7 @@ $(pv_value)</tooltip>
         <width>61</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2528,7 +2526,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -2549,7 +2547,7 @@ $(pv_value)</tooltip>
         <width>67</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -2583,7 +2581,7 @@ $(pv_value)</tooltip>
         <width>67</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -2617,7 +2615,7 @@ $(pv_value)</tooltip>
         <width>67</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -2651,7 +2649,7 @@ $(pv_value)</tooltip>
         <width>67</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -2691,7 +2689,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -2777,7 +2775,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -2814,7 +2812,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2848,7 +2846,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2882,7 +2880,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2916,7 +2914,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2950,7 +2948,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -2984,7 +2982,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3018,7 +3016,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3052,7 +3050,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3086,7 +3084,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3109,7 +3107,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -3130,7 +3128,7 @@ $(pv_value)</tooltip>
         <width>67</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -3196,7 +3194,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3214,7 +3212,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3248,7 +3246,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3282,7 +3280,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3341,7 +3339,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <horizontal_alignment>1</horizontal_alignment>
@@ -3375,7 +3373,7 @@ $(pv_value)</tooltip>
         <width>65</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <format>4</format>
@@ -3399,7 +3397,7 @@ $(pv_value)</tooltip>
         </font>
       </font>
       <foreground_color>
-        <color name="Header_2_ForeGround" red="128" green="128" blue="128">
+        <color name="Header_2_ForeGround" red="255" green="255" blue="255">
         </color>
       </foreground_color>
       <line_color>
@@ -3420,7 +3418,7 @@ $(pv_value)</tooltip>
         <width>80</width>
         <height>17</height>
         <foreground_color>
-          <color name="Read_Foreground" red="0" green="0" blue="0">
+          <color name="Read_Foreground" red="0" green="255" blue="0">
           </color>
         </foreground_color>
         <vertical_alignment>1</vertical_alignment>
@@ -3437,7 +3435,7 @@ $(pv_value)</tooltip>
         <width>80</width>
         <height>19</height>
         <foreground_color>
-          <color name="Write_Foreground" red="0" green="0" blue="0">
+          <color name="Write_Foreground" red="0" green="255" blue="255">
           </color>
         </foreground_color>
         <actions>
@@ -3492,7 +3490,7 @@ $(pv_value)</tooltip>
       </font>
     </font>
     <foreground_color>
-      <color name="Read_Foreground" red="0" green="0" blue="0">
+      <color name="Read_Foreground" red="0" green="255" blue="0">
       </color>
     </foreground_color>
     <horizontal_alignment>1</horizontal_alignment>


### PR DESCRIPTION
In commit 56a314d1d72bc6cc55becebfb3a3e975fae4dcae, the Omsl-FOut records for DBus are refactored. 
In this PR, the corresponding pv in dbus subscreen is updated. 

Also combine with two small corrections.
1: A typo in the evr-vme-300 substitution file. 
2: Default tabs for pulser and I/O in evr-vme-300 screen file.
