### PR TITLE
include kernels >= 5.1.0 (CentOS Stream release 9)

### DIFF
--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -123,7 +123,7 @@ int mrf_mmap_physical(struct uio_info *info, struct vm_area_struct *vma)
         return -EINVAL;
     }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)) || (defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 906))
     vm_flags_set(vma, VM_IO | VM_RESERVED);
 #else
     vma->vm_flags |= VM_IO | VM_RESERVED;

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -123,7 +123,7 @@ int mrf_mmap_physical(struct uio_info *info, struct vm_area_struct *vma)
         return -EINVAL;
     }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
     vm_flags_set(vma, VM_IO | VM_RESERVED);
 #else
     vma->vm_flags |= VM_IO | VM_RESERVED;

--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -123,7 +123,7 @@ int mrf_mmap_physical(struct uio_info *info, struct vm_area_struct *vma)
         return -EINVAL;
     }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
     vm_flags_set(vma, VM_IO | VM_RESERVED);
 #else
     vma->vm_flags |= VM_IO | VM_RESERVED;


### PR DESCRIPTION
On my mrf delivered with CentOS Stream release 9:
/opt/epics/modules/mrfioc2/mrmShared/linux/uio_mrf.c:129:19: error: assignment of read-only member ‘vm_flags’
  129 |     vma->vm_flags |= VM_IO | VM_RESERVED;

Fixed just applying the patch also to kernels >= 5.1.0
