### PR TITLE
adding more db and template files to the install directory

### DIFF
--- a/evrMrmApp/Db/Makefile
+++ b/evrMrmApp/Db/Makefile
@@ -13,6 +13,10 @@ DB += mrmevrbufrx.db
 DB += mrmevrtsbuf.db
 DB += sequencedemo.db
 DB += mrmevrdlymodule.template
+DB += evrSoftSeq.template
+DB += mrmevroutint.db
+DB += evrdcpulser.template
+DB += evrSoftEvt.template
 
 DB += evr-pmc-230.db
 DB += evr-cpci-230.db

--- a/mrmShared/Db/Makefile
+++ b/mrmShared/Db/Makefile
@@ -6,6 +6,7 @@ include $(TOP)/configure/CONFIG
 DB += databuftx.db
 DB += databuftxCtrl.db
 DB += sfp.db
+DB += mrmSoftSeq.template
 
 include $(TOP)/configure/RULES
 #----------------------------------------


### PR DESCRIPTION
In APS we use many db and template files from the installed area to build our own data base. These files are needed by our build system.