### PR TITLE
bug fix: remove macro s in Seq Trigger Source Selection OUT link

### DIFF
--- a/evgMrmApp/Db/evgSoftSeq.template
+++ b/evgMrmApp/Db/evgSoftSeq.template
@@ -43,7 +43,7 @@ record(mbbo, "$(P)TrigSrc-Sel") {
 
 record(mbbo, "$(P)TrigSrc$(s=:)1-Sel") {
   field(DTYP, "Raw Soft Channel")
-  field(OUT , "$(P)TrigSrc$(s=:)-Sel_ PP")
+  field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(UDF,  "0")
   field(ZRST, "Univ0")
   field(ONST, "Univ1")
@@ -83,7 +83,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)1-Sel") {
 # placeholder to OPIs
 record(mbbo, "$(P)TrigSrc$(s=:)2-Sel") {
   field(DTYP, "Raw Soft Channel")
-  field(OUT , "$(P)TrigSrc$(s=:)-Sel_ PP")
+  field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(UDF,  "0")
   field(ZRST, "Rear0")
   field(ONST, "Rear1")


### PR DESCRIPTION
This bug was probably introduced when I added the source 2 of the trigger source. The OUT links of the all sel records should be the same, so the macro s should not be in the OUT link.
I didn't notice this because in my test stand s="". After I fully built my db file at APS where I need to use the macro "s", I found this issue.