### PR TITLE
fix driver error on rhel95

### DIFF
--- a/mrmShared/linux/uio_mrf.c
+++ b/mrmShared/linux/uio_mrf.c
@@ -125,7 +125,7 @@ int mrf_mmap_physical(struct uio_info *info, struct vm_area_struct *vma)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
     vm_flags_set(vma, VM_IO | VM_RESERVED);
-#elif defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 0x906)
+#elif defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 0x905)
     vm_flags_set(vma, VM_IO | VM_RESERVED);
 #else
     vma->vm_flags |= VM_IO | VM_RESERVED;


### PR DESCRIPTION
Recently AlmaLinux 9.5 is released, during test, I found that the backport of `vm_flags_set()` actually starts from RHEL 9.5. 

`RHEL_RELEASE_CODE` should match that accordingly.