### PR TITLE
Improve pv security from protected and private PVs

### DIFF
--- a/evgMrmApp/Db/evgAcTrig.db
+++ b/evgMrmApp/Db/evgAcTrig.db
@@ -1,5 +1,6 @@
 record(longout, "$(P)Divider-SP") {
   field(DESC, "EVG AC Divider")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(OBJ), PROP=Divider")
   field(PINI, "YES")
@@ -25,6 +26,7 @@ record(longin, "$(P)Divider-RB") {
 
 record(ao, "$(P)Phase-SP") {
   field(DESC, "EVG AC Phase Shifter")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT,  "@OBJ=$(OBJ), PROP=Phase")
   field(PINI, "YES")
@@ -58,6 +60,7 @@ record(ai, "$(P)Phase-RB") {
 
 record(bo, "$(P)Bypass-Sel") {
   field(DESC, "Bypass AC divider and Phase shifter")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT,  "@OBJ=$(OBJ), PROP=Bypass")
   field(PINI, "YES")
@@ -79,6 +82,7 @@ record(bi, "$(P)Bypass-RB") {
 
 record(mbbo, "$(P)SyncSrc-Sel") {
   field(DESC, "Synchronization Source")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT,  "@OBJ=$(OBJ), PROP=SyncSrc")
   field(PINI, "YES")

--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -1,5 +1,6 @@
 record(mbbo, "$(P)Src-Sel") {
   field(DESC, "EVG DBUS Source")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(ZRST, "Off")
@@ -42,6 +43,7 @@ record(mbbo, "$(P)Src-Sel") {
 
 record(seq, "$(P)SrcItlk-SQ_") {
   field(DESC, "Sequence to control Src Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)Src1Itlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -87,6 +89,7 @@ record(mbbo, "$(P)MapConv-Sel_") {
 
 record(mbbo, "$(P)Src1-Sel") {
   field(DESC, "EVG DBUS Source (more)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(ZRST, "Off")
@@ -129,6 +132,7 @@ record(mbbo, "$(P)Src1-Sel") {
 
 record(seq, "$(P)Src1Itlk-SQ_") {
   field(DESC, "Sequence to control Src1 Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)SrcItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -174,6 +178,7 @@ record(mbbo, "$(P)MapConv1-Sel_") {
 
 record(mbbo, "$(P)Src2-Sel") {
   field(DESC, "EVG DBUS Source (more+)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(ZRST, "Off")
@@ -213,6 +218,7 @@ record(mbbo, "$(P)Src2-Sel") {
 
 record(seq, "$(P)Src2Itlk-SQ_") {
   field(DESC, "Sequence to control Src1 Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)SrcItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -258,6 +264,7 @@ record(mbbo, "$(P)MapConv2-Sel_") {
 
 record(mbbo, "$(P)Map-Sel") {
   field(DTYP, "Obj Prop uint16")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Source")
   field(PINI, "YES")
   field(VAL,  "0")
@@ -310,8 +317,8 @@ record(mbbiDirect, "$(P)Src2-MbbiDir_") {
 }
 
 record(bo, "$(P)SrcFrontInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input0 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp0")
   field(ZNAM, "Clear")
@@ -321,8 +328,8 @@ record(bo, "$(P)SrcFrontInp0-Sel") {
 }
 
 record(bo, "$(P)SrcFrontInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input1 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp1")
   field(ZNAM, "Clear")
@@ -332,8 +339,8 @@ record(bo, "$(P)SrcFrontInp1-Sel") {
 }
 
 record(bo, "$(P)SrcFrontInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input1 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp2")
   field(ZNAM, "Clear")
@@ -343,8 +350,8 @@ record(bo, "$(P)SrcFrontInp2-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input0 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp0")
   field(ZNAM, "Clear")
@@ -354,8 +361,8 @@ record(bo, "$(P)SrcUnivInp0-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input1 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp1")
   field(ZNAM, "Clear")
@@ -365,8 +372,8 @@ record(bo, "$(P)SrcUnivInp1-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input2 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp2")
   field(ZNAM, "Clear")
@@ -376,8 +383,8 @@ record(bo, "$(P)SrcUnivInp2-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp3-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input3 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp3")
   field(ZNAM, "Clear")
@@ -387,8 +394,8 @@ record(bo, "$(P)SrcUnivInp3-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp4-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input4 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp4")
   field(ZNAM, "Clear")
@@ -398,8 +405,8 @@ record(bo, "$(P)SrcUnivInp4-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp5-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input5 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp5")
   field(ZNAM, "Clear")
@@ -409,8 +416,8 @@ record(bo, "$(P)SrcUnivInp5-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp6-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input6 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp6")
   field(ZNAM, "Clear")
@@ -420,8 +427,8 @@ record(bo, "$(P)SrcUnivInp6-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp7-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input7 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp7")
   field(ZNAM, "Clear")
@@ -431,8 +438,8 @@ record(bo, "$(P)SrcUnivInp7-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp8-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input8 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp8")
   field(ZNAM, "Clear")
@@ -442,8 +449,8 @@ record(bo, "$(P)SrcUnivInp8-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp9-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input9 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp9")
   field(ZNAM, "Clear")
@@ -453,8 +460,8 @@ record(bo, "$(P)SrcUnivInp9-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp10-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input10 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp10")
   field(ZNAM, "Clear")
@@ -464,8 +471,8 @@ record(bo, "$(P)SrcUnivInp10-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp11-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input11 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp11")
   field(ZNAM, "Clear")
@@ -475,8 +482,8 @@ record(bo, "$(P)SrcUnivInp11-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp12-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input12 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp12")
   field(ZNAM, "Clear")
@@ -486,8 +493,8 @@ record(bo, "$(P)SrcUnivInp12-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp13-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input13 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp13")
   field(ZNAM, "Clear")
@@ -497,8 +504,8 @@ record(bo, "$(P)SrcUnivInp13-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp14-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input14 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp14")
   field(ZNAM, "Clear")
@@ -508,8 +515,8 @@ record(bo, "$(P)SrcUnivInp14-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp15-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input15 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp15")
   field(ZNAM, "Clear")
@@ -519,7 +526,7 @@ record(bo, "$(P)SrcUnivInp15-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Front Rear Input0 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp0")
@@ -530,8 +537,8 @@ record(bo, "$(P)SrcRearInp0-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input1 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp1")
   field(ZNAM, "Clear")
@@ -541,8 +548,8 @@ record(bo, "$(P)SrcRearInp1-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input2 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp2")
   field(ZNAM, "Clear")
@@ -552,8 +559,8 @@ record(bo, "$(P)SrcRearInp2-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp3-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input3 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp3")
   field(ZNAM, "Clear")
@@ -563,8 +570,8 @@ record(bo, "$(P)SrcRearInp3-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp4-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input4 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp4")
   field(ZNAM, "Clear")
@@ -574,8 +581,8 @@ record(bo, "$(P)SrcRearInp4-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp5-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input5 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp5")
   field(ZNAM, "Clear")
@@ -585,8 +592,8 @@ record(bo, "$(P)SrcRearInp5-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp6-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input6 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp6")
   field(ZNAM, "Clear")
@@ -596,8 +603,8 @@ record(bo, "$(P)SrcRearInp6-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp7-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input7 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp7")
   field(ZNAM, "Clear")
@@ -607,8 +614,8 @@ record(bo, "$(P)SrcRearInp7-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp8-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input8 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp8")
   field(ZNAM, "Clear")
@@ -618,8 +625,8 @@ record(bo, "$(P)SrcRearInp8-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp9-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input9 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp9")
   field(ZNAM, "Clear")
@@ -629,8 +636,8 @@ record(bo, "$(P)SrcRearInp9-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp10-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input10 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp10")
   field(ZNAM, "Clear")
@@ -640,8 +647,8 @@ record(bo, "$(P)SrcRearInp10-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp11-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input11 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp11")
   field(ZNAM, "Clear")
@@ -651,8 +658,8 @@ record(bo, "$(P)SrcRearInp11-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp12-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input12 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp12")
   field(ZNAM, "Clear")
@@ -662,8 +669,8 @@ record(bo, "$(P)SrcRearInp12-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp13-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input13 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp13")
   field(ZNAM, "Clear")
@@ -673,8 +680,8 @@ record(bo, "$(P)SrcRearInp13-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp14-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input14 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp14")
   field(ZNAM, "Clear")
@@ -684,8 +691,8 @@ record(bo, "$(P)SrcRearInp14-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp15-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input15 on Dbus")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp15")
   field(ZNAM, "Clear")
@@ -703,6 +710,7 @@ record(bo, "$(P)SrcRearInp15-Sel") {
 
 record(bo, "$(P)Omsl-Sel") {
   field(DESC, "Multiple sources")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "1")
   field(UDF,  "0")

--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -61,7 +61,7 @@ record(seq, "$(P)SrcItlk-SQ_") {
 }
 
 record(mbbo, "$(P)MapConv-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Raw Soft Channel")
   field(ZRVL, "0")
   field(ONVL, "1")
@@ -148,7 +148,7 @@ record(seq, "$(P)Src1Itlk-SQ_") {
 }
 
 record(mbbo, "$(P)MapConv1-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Raw Soft Channel")
   field(ZRVL, "0")
   field(ONVL, "1")
@@ -232,7 +232,7 @@ record(seq, "$(P)Src2Itlk-SQ_") {
 }
 
 record(mbbo, "$(P)MapConv2-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Raw Soft Channel")
   field(ZRVL, "0")
   field(ONVL, "1")
@@ -292,25 +292,25 @@ record(mbbo, "$(P)Map-Sel") {
 # Input to the Distributed Bus
 #
 record(mbbiDirect, "$(P)Src-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Dbus source")
   field(INP,  "$(P)Src-Sel.RVAL CP")
 }
 
 record(mbbiDirect, "$(P)Src1-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Dbus source 1")
   field(INP,  "$(P)Src1-Sel.RVAL CP")
 }
 
 record(mbbiDirect, "$(P)Src2-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Dbus source 2")
   field(INP,  "$(P)Src2-Sel.RVAL CP")
 }
 
 record(bo, "$(P)SrcFrontInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input0 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp0")
@@ -321,7 +321,7 @@ record(bo, "$(P)SrcFrontInp0-Sel") {
 }
 
 record(bo, "$(P)SrcFrontInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input1 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp1")
@@ -332,7 +332,7 @@ record(bo, "$(P)SrcFrontInp1-Sel") {
 }
 
 record(bo, "$(P)SrcFrontInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Input1 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):FrontInp2")
@@ -343,7 +343,7 @@ record(bo, "$(P)SrcFrontInp2-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input0 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp0")
@@ -354,7 +354,7 @@ record(bo, "$(P)SrcUnivInp0-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input1 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp1")
@@ -365,7 +365,7 @@ record(bo, "$(P)SrcUnivInp1-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input2 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp2")
@@ -376,7 +376,7 @@ record(bo, "$(P)SrcUnivInp2-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp3-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input3 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp3")
@@ -387,7 +387,7 @@ record(bo, "$(P)SrcUnivInp3-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp4-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input4 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp4")
@@ -398,7 +398,7 @@ record(bo, "$(P)SrcUnivInp4-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp5-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input5 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp5")
@@ -409,7 +409,7 @@ record(bo, "$(P)SrcUnivInp5-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp6-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input6 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp6")
@@ -420,7 +420,7 @@ record(bo, "$(P)SrcUnivInp6-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp7-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input7 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp7")
@@ -431,7 +431,7 @@ record(bo, "$(P)SrcUnivInp7-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp8-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input8 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp8")
@@ -442,7 +442,7 @@ record(bo, "$(P)SrcUnivInp8-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp9-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input9 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp9")
@@ -453,7 +453,7 @@ record(bo, "$(P)SrcUnivInp9-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp10-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input10 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp10")
@@ -464,7 +464,7 @@ record(bo, "$(P)SrcUnivInp10-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp11-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input11 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp11")
@@ -475,7 +475,7 @@ record(bo, "$(P)SrcUnivInp11-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp12-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input12 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp12")
@@ -486,7 +486,7 @@ record(bo, "$(P)SrcUnivInp12-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp13-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input13 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp13")
@@ -497,7 +497,7 @@ record(bo, "$(P)SrcUnivInp13-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp14-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input14 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp14")
@@ -508,7 +508,7 @@ record(bo, "$(P)SrcUnivInp14-Sel") {
 }
 
 record(bo, "$(P)SrcUnivInp15-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Univ Input15 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):UnivInp15")
@@ -519,7 +519,7 @@ record(bo, "$(P)SrcUnivInp15-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input0 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp0")
@@ -530,7 +530,7 @@ record(bo, "$(P)SrcRearInp0-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input1 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp1")
@@ -541,7 +541,7 @@ record(bo, "$(P)SrcRearInp1-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input2 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp2")
@@ -552,7 +552,7 @@ record(bo, "$(P)SrcRearInp2-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp3-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input3 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp3")
@@ -563,7 +563,7 @@ record(bo, "$(P)SrcRearInp3-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp4-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input4 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp4")
@@ -574,7 +574,7 @@ record(bo, "$(P)SrcRearInp4-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp5-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input5 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp5")
@@ -585,7 +585,7 @@ record(bo, "$(P)SrcRearInp5-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp6-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input6 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp6")
@@ -596,7 +596,7 @@ record(bo, "$(P)SrcRearInp6-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp7-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input7 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp7")
@@ -607,7 +607,7 @@ record(bo, "$(P)SrcRearInp7-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp8-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input8 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp8")
@@ -618,7 +618,7 @@ record(bo, "$(P)SrcRearInp8-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp9-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input9 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp9")
@@ -629,7 +629,7 @@ record(bo, "$(P)SrcRearInp9-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp10-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input10 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp10")
@@ -640,7 +640,7 @@ record(bo, "$(P)SrcRearInp10-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp11-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input11 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp11")
@@ -651,7 +651,7 @@ record(bo, "$(P)SrcRearInp11-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp12-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input12 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp12")
@@ -662,7 +662,7 @@ record(bo, "$(P)SrcRearInp12-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp13-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input13 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp13")
@@ -673,7 +673,7 @@ record(bo, "$(P)SrcRearInp13-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp14-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input14 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp14")
@@ -684,7 +684,7 @@ record(bo, "$(P)SrcRearInp14-Sel") {
 }
 
 record(bo, "$(P)SrcRearInp15-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Front Rear Input15 on Dbus")
   field(DTYP, "EVG Dbus")
   field(OUT , "#C0 S$(dbusBit) @$(EVG):RearInp15")
@@ -713,7 +713,7 @@ record(bo, "$(P)Omsl-Sel") {
 }
 
 record(dfanout, "$(P)Omsl-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)Omsl0-FOut_ PP")
   field(OUTB, "$(P)Omsl1-FOut_ PP")
@@ -722,7 +722,7 @@ record(dfanout, "$(P)Omsl-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl0-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)SrcFrontInp0-Sel.OMSL")
   field(OUTB, "$(P)SrcFrontInp1-Sel.OMSL")
@@ -735,7 +735,7 @@ record(dfanout, "$(P)Omsl0-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl1-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)SrcUnivInp6-Sel.OMSL")
   field(OUTB, "$(P)SrcUnivInp7-Sel.OMSL")
@@ -746,7 +746,7 @@ record(dfanout, "$(P)Omsl1-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl2-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)SrcRearInp0-Sel.OMSL")
   field(OUTB, "$(P)SrcRearInp1-Sel.OMSL")
@@ -759,7 +759,7 @@ record(dfanout, "$(P)Omsl2-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl3-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)SrcRearInp8-Sel.OMSL")
   field(OUTB, "$(P)SrcRearInp9-Sel.OMSL")

--- a/evgMrmApp/Db/evgEvtClk.db
+++ b/evgMrmApp/Db/evgEvtClk.db
@@ -1,5 +1,6 @@
 record(mbbo, "$(P)Source-Sel") {
   field(DESC, "EVG Evt Clk Source")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT,  "@OBJ=$(OBJ), PROP=Source")
   field(PINI, "YES")
@@ -45,6 +46,7 @@ record(mbbi, "$(P)Source-RB") {
 
 record(ao, "$(P)RFFreq-SP") {
   field(DESC, "EVG RF Frequency")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT,  "@OBJ=$(OBJ), PROP=RFFreq")
   field(PINI, "YES")
@@ -81,6 +83,7 @@ record(ai, "$(P)RFFreq-RB") {
 
 record(longout, "$(P)RFDiv-SP") {
   field(DESC, "RF Divider")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(OBJ), PROP=RFDiv")
   field(PINI, "YES")
@@ -107,6 +110,7 @@ record(longin, "$(P)RFDiv-RB") {
 
 record(ao, "$(P)FracSynFreq-SP") {
   field(DESC, "Fractional Synthesizer Freq")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT,  "@OBJ=$(OBJ), PROP=FracSynFreq")
   field(EGU,  "MHz")
@@ -160,6 +164,7 @@ record(bi, "$(P)Pll-Sts") {
 
 record(mbbo, "$(P)PLL-Bandwidth-Sel") {
     field( DESC, "EVG Evt Clock Bandwidth")
+    field( ASG,  "$(ASGPROTECTED=protected)")
     field( DTYP, "Obj Prop uint16")
     field( OUT,  "@OBJ=$(OBJ), PROP=PLL Bandwidth")
     field( PINI, "YES")

--- a/evgMrmApp/Db/evgInput.db
+++ b/evgMrmApp/Db/evgInput.db
@@ -1,5 +1,6 @@
 record(bo, "$(P)EnaIrq-Sel") {
   field(DESC, "Enable External Input IRQ")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=IRQ")
   field(ZNAM, "Disabled")
@@ -21,6 +22,7 @@ record(bi, "$(P)EnaIrq-RB") {
 
 record(ao, "$(P)FPMask-Sel") {
   field(DESC, "FPxMask")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=FPMASK")
   field(FLNK, "$(P)FPMask-RB")
@@ -33,6 +35,7 @@ record(ai, "$(P)FPMask-RB") {
 
 record(bo, "$(P)EnaMxcr-Sel") {
   field(DESC, "Enable Hardware Mxc Reset")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Hw Reset MXC")
   field(ZNAM, "Disabled")

--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -2,6 +2,7 @@
 
 record(mbbo, "$(P)Enable-Sel") {
   field(DESC, "EVG Master Enable")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")
   field(ZRST, "Disabled")
@@ -58,6 +59,7 @@ record(waveform, "$(P)Label-I") {
 
 record(bo, "$(P)ResetMxc-Cmd") {
   field(DTYP, "Obj Prop bool")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Reset MXC")
   field(DESC, "EVG Reset MXC")
   field(PINI, "YES")
@@ -67,6 +69,7 @@ record(bo, "$(P)ResetMxc-Cmd") {
 
 record(longout, "$(P)SendEvt-SP") {
   field(DESC, "EVG Software Event Code")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(OBJ), PROP=EvtCode")
   field(UDF,  "0")
@@ -88,6 +91,7 @@ record (stringin, "$(P)Timestamp-RB") {
 
 record(bo, "$(P)SimTimestamp-Sel") {
   field(DTYP, "Obj Prop bool")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=SimTime")
   field(OMSL, "closed_loop")
   field(DOL , "$(P)PpsInp-MbbiDir_.BF CP")
@@ -97,6 +101,7 @@ record(bo, "$(P)SimTimestamp-Sel") {
 
 record(bo, "$(P)SoftTickSecond-Cmd") {
   field(DTYP, "Obj Prop command")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Tick second via EPICS scan")
   field(OUT , "@OBJ=$(OBJ), PROP=SoftTick")
   field(DISV, 0)
@@ -111,12 +116,14 @@ record(ai, "$(P)TimeErr-I") {
 
 record(bo,"$(P)SyncTimestamp-Cmd" ) {
   field(DTYP, "Obj Prop command")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Sync TS")
   field(DESC, "EVG Sync TimeStamp")
 }
 
 record(mbbo, "$(P)PpsInp-Sel") {
   field(DESC, "EVG Pps Input")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(UDF,  "0")
   field(VAL,  "0")
@@ -169,6 +176,7 @@ record(mbbiDirect, "$(P)PpsInp-MbbiDir_") {
 }
 
 record(seq, "$(P)PpsInp-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)PpsInpItlk-SQ_.PROC")
   field(DOL2, "0")
@@ -176,6 +184,7 @@ record(seq, "$(P)PpsInp-SQ_"){
 }
 
 record(seq, "$(P)PpsInpItlk-SQ_") {
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DESC, "Sequence to control 1PPS Select")
   field(DOL1, "1")
   field(LNK1, "$(P)PpsInp1Itlk-SQ_.DISA NPP NMS")
@@ -195,6 +204,7 @@ record(seq, "$(P)PpsInpItlk-SQ_") {
 
 record(mbbo, "$(P)PpsInp1-Sel") {
   field(DESC, "EVG Pps Input (more)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(UDF,  "0")
   field(VAL,  "0")
@@ -239,6 +249,7 @@ record(mbbiDirect, "$(P)PpsInp1-MbbiDir_") {
 }
 
 record(seq, "$(P)PpsInp1-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)PpsInp1Itlk-SQ_.PROC")
   field(DOL2, "0")
@@ -247,6 +258,7 @@ record(seq, "$(P)PpsInp1-SQ_"){
 
 record(seq, "$(P)PpsInp1Itlk-SQ_") {
   field(DESC, "Sequence to control 1PPS Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -265,6 +277,7 @@ record(seq, "$(P)PpsInp1Itlk-SQ_") {
 
 record(mbbo, "$(P)PpsInp2-Sel") {
   field(DESC, "EVG Pps Input (more+)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(UDF,  "0")
   field(VAL,  "0")
@@ -317,6 +330,7 @@ record(mbbiDirect, "$(P)PpsInp2-MbbiDir_") {
 }
 
 record(seq, "$(P)PpsInp2-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)PpsInp2Itlk-SQ_.PROC")
   field(DOL2, "0")
@@ -324,6 +338,7 @@ record(seq, "$(P)PpsInp2-SQ_"){
 }
 
 record(seq, "$(P)PpsInp2Itlk-SQ_") {
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DESC, "Sequence to control 1PPS Select")
   field(DOL1, "1")
   field(LNK1, "$(P)PpsInpItlk-SQ_.DISA NPP NMS")
@@ -353,6 +368,7 @@ record(longin, "$(P)DbusStatus-RB" ) {
 #
 record(mbbo, "$(P)TSGen-SP") {
   field(DESC, "EVG TS Generator")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT,  "@OBJ=$(OBJ), PROP=TS Generator")
   field(PINI, "YES")
@@ -396,6 +412,7 @@ record(mbbi, "$(P)TSGen-RB") {
 }
 
 record(bo,"$(P)ResetFracSynth-Cmd" ) {
+    field (ASG,  "$(ASGPROTECTED=protected)")
     field( DTYP, "Obj Prop command")
     field( OUT , "@OBJ=$(OBJ), PROP=Reset Frac Synth")
     field( DESC, "Reset")

--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -163,7 +163,7 @@ record(mbbo, "$(P)PpsInp-Sel") {
 # interrupt of the corresponding external input.
 #
 record(mbbiDirect, "$(P)PpsInp-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp-Sel.RVAL NPP")
 }
@@ -233,7 +233,7 @@ record(mbbo, "$(P)PpsInp1-Sel") {
 # interrupt of the corresponding external input.
 #
 record(mbbiDirect, "$(P)PpsInp1-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp1-Sel.RVAL NPP")
 }
@@ -311,7 +311,7 @@ record(mbbo, "$(P)PpsInp2-Sel") {
 # interrupt of the corresponding external input.
 #
 record(mbbiDirect, "$(P)PpsInp2-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Pps Input")
   field(INP,  "$(P)PpsInp2-Sel.RVAL NPP")
 }

--- a/evgMrmApp/Db/evgMxc.db
+++ b/evgMrmApp/Db/evgMxc.db
@@ -8,6 +8,7 @@ record(bi, "$(P)Status-RB") {
 
 record(bo, "$(P)Polarity-Sel") {
   field(DESC, "EVG Mux Output Polarity")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Polarity")
   field(PINI, "YES")
@@ -29,6 +30,7 @@ record(bi, "$(P)Polarity-RB") {
 
 record(ao, "$(P)Frequency-SP") {
   field(DESC, "EVG Mux Frequency")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Frequency")
   field(EGU , "Hz")
@@ -54,6 +56,7 @@ record(ai, "$(P)Frequency-RB") {
 
 record(longout, "$(P)Prescaler-SP") {
   field(DESC, "EVG Mux Prescaler")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Prescaler")
   field(PINI, "YES")

--- a/evgMrmApp/Db/evgMxc.db
+++ b/evgMrmApp/Db/evgMxc.db
@@ -75,7 +75,7 @@ record(longin , "$(P)Prescaler-RB") {
 # When Evt Clock Frequency changes, Mxc Freq changes keeping the Prescaler same.
 #
 record(ai, "$(P)EvtClkFreq-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(INP,  "$(PP=$(SYS){$(D)-)EvtClk$(s=})Frequency-RB CP")
   field(FLNK, "$(P)Frequency-RB")
 }

--- a/evgMrmApp/Db/evgOutput.db
+++ b/evgMrmApp/Db/evgOutput.db
@@ -1,4 +1,5 @@
 record(mbbo, "$(P)Source-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=Source")
   field(ZRST, "Off")

--- a/evgMrmApp/Db/evgSoftSeq.template
+++ b/evgMrmApp/Db/evgSoftSeq.template
@@ -6,6 +6,7 @@ record(fanout, "$(P)TrigSrc$(s=:)Init-FOut_") {
 }
 
 record(mbbo, "$(P)TrigSrc-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(UDF,  "0")
@@ -42,6 +43,7 @@ record(mbbo, "$(P)TrigSrc-Sel") {
 }
 
 record(mbbo, "$(P)TrigSrc$(s=:)1-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(UDF,  "0")
@@ -82,6 +84,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)1-Sel") {
 
 # placeholder to OPIs
 record(mbbo, "$(P)TrigSrc$(s=:)2-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(UDF,  "0")

--- a/evgMrmApp/Db/evgSoftSeq.template
+++ b/evgMrmApp/Db/evgSoftSeq.template
@@ -1,7 +1,7 @@
 # linked from mrmSoftSeq.template
 # $(P)InitSeq$(s=:)Cont-FOut_
 record(fanout, "$(P)TrigSrc$(s=:)Init-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(LNK1, "$(P)TrigSrc-Sel_")
 }
 
@@ -121,7 +121,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)2-Sel") {
 }
 
 record(longout, "$(P)TrigSrc-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TRIG_SRC")
   field(VAL , "0x03000000") # default to None
@@ -129,7 +129,7 @@ record(longout, "$(P)TrigSrc-Sel_") {
 }
 
 record(longin, "$(P)TrigSrc-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(INP , "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TRIG_SRC")
   field(SCAN, "I/O Intr")
@@ -192,13 +192,13 @@ record(stringin, "$(P)TrigSrc-RB") {
 #(only if TsInpMode = EGU).
 #
 record(ai, "$(P)EvtClkFreq-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(INP,  "$(PP=$(SYS){$(D)-)EvtClk$(s=})Frequency-RB CP")
   field(FLNK, "$(P)EvtClkFreq$(s=:)Cont-RB_")
 }
 
 record(ao, "$(P)EvtClkFreq$(s=:)Cont-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OUT,  "$(P)Timestamp-RB.PROC")
   field(VAL,  "1")
 }

--- a/evgMrmApp/Db/evgTrigEvt.db
+++ b/evgMrmApp/Db/evgTrigEvt.db
@@ -1,6 +1,7 @@
 
 record(longout, "$(P)EvtCode-SP") {
   field(DESC, "EVG Trigger Event Code")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(OBJ), PROP=EvtCode")
   field(PINI, "YES")
@@ -26,6 +27,7 @@ record(longin, "$(P)EvtCode-RB") {
 
 record(mbbo, "$(P)TrigSrc-Sel") {
   field(DESC, "EVG Trig Evt Trig")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -75,6 +77,7 @@ record(mbbiDirect, "$(P)TrigSrc-MbbiDir_") {
 }
 
 record(seq, "$(P)TrigSrc-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)TrigSrcItlk-SQ_.PROC")
   field(DOL2, "0")
@@ -82,6 +85,7 @@ record(seq, "$(P)TrigSrc-SQ_"){
 }
 
 record(seq, "$(P)TrigSrcItlk-SQ_") {
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DESC, "Sequence to control TrigSrc Select")
   field(DOL1, "1")
   field(LNK1, "$(P)TrigSrc1Itlk-SQ_.DISA NPP NMS")
@@ -101,6 +105,7 @@ record(seq, "$(P)TrigSrcItlk-SQ_") {
 
 record(mbbo, "$(P)TrigSrc1-Sel") {
   field(DESC, "EVG Trig Evt Trig (more)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -148,6 +153,7 @@ record(mbbiDirect, "$(P)TrigSrc1-MbbiDir_") {
 }
 
 record(seq, "$(P)TrigSrc1-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)TrigSrc1Itlk-SQ_.PROC")
   field(DOL2, "0")
@@ -156,6 +162,7 @@ record(seq, "$(P)TrigSrc1-SQ_"){
 
 record(seq, "$(P)TrigSrc1Itlk-SQ_") {
   field(DESC, "Sequence to control TrigSrc Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)TrigSrcItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -174,6 +181,7 @@ record(seq, "$(P)TrigSrc1Itlk-SQ_") {
 
 record(mbbo, "$(P)TrigSrc2-Sel") {
   field(DESC, "EVG Trig Evt Trig (more+)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -222,6 +230,7 @@ record(mbbiDirect, "$(P)TrigSrc2-MbbiDir_") {
 }
 
 record(seq, "$(P)TrigSrc2-SQ_"){
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "0")
   field(LNK1, "$(P)TrigSrc2Itlk-SQ_.PROC")
   field(DOL2, "0")
@@ -230,6 +239,7 @@ record(seq, "$(P)TrigSrc2-SQ_"){
 
 record(seq, "$(P)TrigSrc2Itlk-SQ_") {
   field(DESC, "Sequence to control TrigSrc Select")
+  field(ASG,  "$(ASGPRIVATE=private)")
   field(DOL1, "1")
   field(LNK1, "$(P)TrigSrcItlk-SQ_.DISA NPP NMS")
   field(DOL2, "1")
@@ -247,7 +257,7 @@ record(seq, "$(P)TrigSrc2Itlk-SQ_") {
 }
 
 record(bo, "$(P)TrigSrcMxc0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc0")
   field(ZNAM, "Clear")
@@ -257,7 +267,7 @@ record(bo, "$(P)TrigSrcMxc0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc1")
   field(ZNAM, "Clear")
@@ -267,7 +277,7 @@ record(bo, "$(P)TrigSrcMxc1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc2")
   field(ZNAM, "Clear")
@@ -277,7 +287,7 @@ record(bo, "$(P)TrigSrcMxc2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc3-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc3")
   field(ZNAM, "Clear")
@@ -287,7 +297,7 @@ record(bo, "$(P)TrigSrcMxc3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc4-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc4")
   field(ZNAM, "Clear")
@@ -297,7 +307,7 @@ record(bo, "$(P)TrigSrcMxc4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc5-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc5")
   field(ZNAM, "Clear")
@@ -307,7 +317,7 @@ record(bo, "$(P)TrigSrcMxc5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc6-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc6")
   field(ZNAM, "Clear")
@@ -317,7 +327,7 @@ record(bo, "$(P)TrigSrcMxc6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc7-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc7")
   field(ZNAM, "Clear")
@@ -327,7 +337,7 @@ record(bo, "$(P)TrigSrcMxc7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcAC-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG Trig Evt AC")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):AcTrig")
   field(ZNAM, "Clear")
@@ -337,7 +347,7 @@ record(bo, "$(P)TrigSrcAC-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp0")
   field(ZNAM, "Clear")
@@ -347,7 +357,7 @@ record(bo, "$(P)TrigSrcFrontInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp1")
   field(ZNAM, "Clear")
@@ -357,7 +367,7 @@ record(bo, "$(P)TrigSrcFrontInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp0")
   field(ZNAM, "Clear")
@@ -367,7 +377,7 @@ record(bo, "$(P)TrigSrcUnivInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp1")
   field(ZNAM, "Clear")
@@ -377,7 +387,7 @@ record(bo, "$(P)TrigSrcUnivInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp2")
   field(ZNAM, "Clear")
@@ -387,7 +397,7 @@ record(bo, "$(P)TrigSrcUnivInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp3-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp3")
   field(ZNAM, "Clear")
@@ -397,7 +407,7 @@ record(bo, "$(P)TrigSrcUnivInp3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp4-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp4")
   field(ZNAM, "Clear")
@@ -407,7 +417,7 @@ record(bo, "$(P)TrigSrcUnivInp4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp5-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp5")
   field(ZNAM, "Clear")
@@ -417,7 +427,7 @@ record(bo, "$(P)TrigSrcUnivInp5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp6-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp6")
   field(ZNAM, "Clear")
@@ -427,7 +437,7 @@ record(bo, "$(P)TrigSrcUnivInp6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp7-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp7")
   field(ZNAM, "Clear")
@@ -437,7 +447,7 @@ record(bo, "$(P)TrigSrcUnivInp7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp8-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp8")
   field(ZNAM, "Clear")
@@ -447,7 +457,7 @@ record(bo, "$(P)TrigSrcUnivInp8-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp9-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp9")
   field(ZNAM, "Clear")
@@ -457,7 +467,7 @@ record(bo, "$(P)TrigSrcUnivInp9-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp10-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp10")
   field(ZNAM, "Clear")
@@ -467,7 +477,7 @@ record(bo, "$(P)TrigSrcUnivInp10-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp11-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp11")
   field(ZNAM, "Clear")
@@ -477,7 +487,7 @@ record(bo, "$(P)TrigSrcUnivInp11-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp12-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp12")
   field(ZNAM, "Clear")
@@ -487,7 +497,7 @@ record(bo, "$(P)TrigSrcUnivInp12-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp13-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp13")
   field(ZNAM, "Clear")
@@ -497,7 +507,7 @@ record(bo, "$(P)TrigSrcUnivInp13-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp14-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp14")
   field(ZNAM, "Clear")
@@ -507,7 +517,7 @@ record(bo, "$(P)TrigSrcUnivInp14-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp15-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp15")
   field(ZNAM, "Clear")
@@ -517,7 +527,7 @@ record(bo, "$(P)TrigSrcUnivInp15-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp2")
   field(ZNAM, "Clear")
@@ -527,7 +537,7 @@ record(bo, "$(P)TrigSrcFrontInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp0-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp0")
   field(ZNAM, "Clear")
@@ -537,7 +547,7 @@ record(bo, "$(P)TrigSrcRearInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp1-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp1")
   field(ZNAM, "Clear")
@@ -547,7 +557,7 @@ record(bo, "$(P)TrigSrcRearInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp2-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp2")
   field(ZNAM, "Clear")
@@ -557,7 +567,7 @@ record(bo, "$(P)TrigSrcRearInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp3-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp3")
   field(ZNAM, "Clear")
@@ -567,7 +577,7 @@ record(bo, "$(P)TrigSrcRearInp3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp4-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp4")
   field(ZNAM, "Clear")
@@ -577,7 +587,7 @@ record(bo, "$(P)TrigSrcRearInp4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp5-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp5")
   field(ZNAM, "Clear")
@@ -587,7 +597,7 @@ record(bo, "$(P)TrigSrcRearInp5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp6-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp6")
   field(ZNAM, "Clear")
@@ -597,7 +607,7 @@ record(bo, "$(P)TrigSrcRearInp6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp7-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp7")
   field(ZNAM, "Clear")
@@ -607,7 +617,7 @@ record(bo, "$(P)TrigSrcRearInp7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp8-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp8")
   field(ZNAM, "Clear")
@@ -617,7 +627,7 @@ record(bo, "$(P)TrigSrcRearInp8-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp9-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp9")
   field(ZNAM, "Clear")
@@ -627,7 +637,7 @@ record(bo, "$(P)TrigSrcRearInp9-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp10-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp10")
   field(ZNAM, "Clear")
@@ -637,7 +647,7 @@ record(bo, "$(P)TrigSrcRearInp10-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp11-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp11")
   field(ZNAM, "Clear")
@@ -647,7 +657,7 @@ record(bo, "$(P)TrigSrcRearInp11-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp12-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp12")
   field(ZNAM, "Clear")
@@ -657,7 +667,7 @@ record(bo, "$(P)TrigSrcRearInp12-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp13-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp13")
   field(ZNAM, "Clear")
@@ -667,7 +677,7 @@ record(bo, "$(P)TrigSrcRearInp13-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp14-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp14")
   field(ZNAM, "Clear")
@@ -677,7 +687,7 @@ record(bo, "$(P)TrigSrcRearInp14-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp15-Sel") {
-  field(ASG, "$(ASGPRIVATE=private)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp15")
   field(ZNAM, "Clear")
@@ -696,6 +706,7 @@ record(bo, "$(P)TrigSrcRearInp15-Sel") {
 
 record(bo, "$(P)Omsl-Sel") {
   field(DESC, "Multiple sources")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(VAL,  "1")
   field(UDF,  "0")

--- a/evgMrmApp/Db/evgTrigEvt.db
+++ b/evgMrmApp/Db/evgTrigEvt.db
@@ -69,7 +69,7 @@ record(mbbo, "$(P)TrigSrc-Sel") {
 }
 
 record(mbbiDirect, "$(P)TrigSrc-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Trig Evt Trig")
   field(INP,  "$(P)TrigSrc-Sel.RVAL")
 }
@@ -142,7 +142,7 @@ record(mbbo, "$(P)TrigSrc1-Sel") {
 }
 
 record(mbbiDirect, "$(P)TrigSrc1-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Trig Evt Trig")
   field(INP,  "$(P)TrigSrc1-Sel.RVAL")
 }
@@ -216,7 +216,7 @@ record(mbbo, "$(P)TrigSrc2-Sel") {
 }
 
 record(mbbiDirect, "$(P)TrigSrc2-MbbiDir_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "EVG Trig Evt Trig")
   field(INP,  "$(P)TrigSrc2-Sel.RVAL")
 }
@@ -247,7 +247,7 @@ record(seq, "$(P)TrigSrc2Itlk-SQ_") {
 }
 
 record(bo, "$(P)TrigSrcMxc0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc0")
   field(ZNAM, "Clear")
@@ -257,7 +257,7 @@ record(bo, "$(P)TrigSrcMxc0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc1")
   field(ZNAM, "Clear")
@@ -267,7 +267,7 @@ record(bo, "$(P)TrigSrcMxc1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc2")
   field(ZNAM, "Clear")
@@ -277,7 +277,7 @@ record(bo, "$(P)TrigSrcMxc2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc3-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc3")
   field(ZNAM, "Clear")
@@ -287,7 +287,7 @@ record(bo, "$(P)TrigSrcMxc3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc4-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc4")
   field(ZNAM, "Clear")
@@ -297,7 +297,7 @@ record(bo, "$(P)TrigSrcMxc4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc5-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc5")
   field(ZNAM, "Clear")
@@ -307,7 +307,7 @@ record(bo, "$(P)TrigSrcMxc5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc6-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc6")
   field(ZNAM, "Clear")
@@ -317,7 +317,7 @@ record(bo, "$(P)TrigSrcMxc6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcMxc7-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt Mxc")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):Mxc7")
   field(ZNAM, "Clear")
@@ -327,7 +327,7 @@ record(bo, "$(P)TrigSrcMxc7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcAC-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG Trig Evt AC")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):AcTrig")
   field(ZNAM, "Clear")
@@ -337,7 +337,7 @@ record(bo, "$(P)TrigSrcAC-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp0")
   field(ZNAM, "Clear")
@@ -347,7 +347,7 @@ record(bo, "$(P)TrigSrcFrontInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp1")
   field(ZNAM, "Clear")
@@ -357,7 +357,7 @@ record(bo, "$(P)TrigSrcFrontInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp0")
   field(ZNAM, "Clear")
@@ -367,7 +367,7 @@ record(bo, "$(P)TrigSrcUnivInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp1")
   field(ZNAM, "Clear")
@@ -377,7 +377,7 @@ record(bo, "$(P)TrigSrcUnivInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp2")
   field(ZNAM, "Clear")
@@ -387,7 +387,7 @@ record(bo, "$(P)TrigSrcUnivInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp3-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp3")
   field(ZNAM, "Clear")
@@ -397,7 +397,7 @@ record(bo, "$(P)TrigSrcUnivInp3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp4-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp4")
   field(ZNAM, "Clear")
@@ -407,7 +407,7 @@ record(bo, "$(P)TrigSrcUnivInp4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp5-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp5")
   field(ZNAM, "Clear")
@@ -417,7 +417,7 @@ record(bo, "$(P)TrigSrcUnivInp5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp6-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp6")
   field(ZNAM, "Clear")
@@ -427,7 +427,7 @@ record(bo, "$(P)TrigSrcUnivInp6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp7-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp7")
   field(ZNAM, "Clear")
@@ -437,7 +437,7 @@ record(bo, "$(P)TrigSrcUnivInp7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp8-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp8")
   field(ZNAM, "Clear")
@@ -447,7 +447,7 @@ record(bo, "$(P)TrigSrcUnivInp8-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp9-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp9")
   field(ZNAM, "Clear")
@@ -457,7 +457,7 @@ record(bo, "$(P)TrigSrcUnivInp9-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp10-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp10")
   field(ZNAM, "Clear")
@@ -467,7 +467,7 @@ record(bo, "$(P)TrigSrcUnivInp10-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp11-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp11")
   field(ZNAM, "Clear")
@@ -477,7 +477,7 @@ record(bo, "$(P)TrigSrcUnivInp11-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp12-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp12")
   field(ZNAM, "Clear")
@@ -487,7 +487,7 @@ record(bo, "$(P)TrigSrcUnivInp12-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp13-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp13")
   field(ZNAM, "Clear")
@@ -497,7 +497,7 @@ record(bo, "$(P)TrigSrcUnivInp13-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp14-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp14")
   field(ZNAM, "Clear")
@@ -507,7 +507,7 @@ record(bo, "$(P)TrigSrcUnivInp14-Sel") {
 }
 
 record(bo, "$(P)TrigSrcUnivInp15-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):UnivInp15")
   field(ZNAM, "Clear")
@@ -517,7 +517,7 @@ record(bo, "$(P)TrigSrcUnivInp15-Sel") {
 }
 
 record(bo, "$(P)TrigSrcFrontInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):FrontInp2")
   field(ZNAM, "Clear")
@@ -527,7 +527,7 @@ record(bo, "$(P)TrigSrcFrontInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp0-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp0")
   field(ZNAM, "Clear")
@@ -537,7 +537,7 @@ record(bo, "$(P)TrigSrcRearInp0-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp1-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp1")
   field(ZNAM, "Clear")
@@ -547,7 +547,7 @@ record(bo, "$(P)TrigSrcRearInp1-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp2-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp2")
   field(ZNAM, "Clear")
@@ -557,7 +557,7 @@ record(bo, "$(P)TrigSrcRearInp2-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp3-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp3")
   field(ZNAM, "Clear")
@@ -567,7 +567,7 @@ record(bo, "$(P)TrigSrcRearInp3-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp4-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp4")
   field(ZNAM, "Clear")
@@ -577,7 +577,7 @@ record(bo, "$(P)TrigSrcRearInp4-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp5-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp5")
   field(ZNAM, "Clear")
@@ -587,7 +587,7 @@ record(bo, "$(P)TrigSrcRearInp5-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp6-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp6")
   field(ZNAM, "Clear")
@@ -597,7 +597,7 @@ record(bo, "$(P)TrigSrcRearInp6-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp7-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp7")
   field(ZNAM, "Clear")
@@ -607,7 +607,7 @@ record(bo, "$(P)TrigSrcRearInp7-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp8-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp8")
   field(ZNAM, "Clear")
@@ -617,7 +617,7 @@ record(bo, "$(P)TrigSrcRearInp8-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp9-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp9")
   field(ZNAM, "Clear")
@@ -627,7 +627,7 @@ record(bo, "$(P)TrigSrcRearInp9-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp10-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp10")
   field(ZNAM, "Clear")
@@ -637,7 +637,7 @@ record(bo, "$(P)TrigSrcRearInp10-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp11-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp11")
   field(ZNAM, "Clear")
@@ -647,7 +647,7 @@ record(bo, "$(P)TrigSrcRearInp11-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp12-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp12")
   field(ZNAM, "Clear")
@@ -657,7 +657,7 @@ record(bo, "$(P)TrigSrcRearInp12-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp13-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp13")
   field(ZNAM, "Clear")
@@ -667,7 +667,7 @@ record(bo, "$(P)TrigSrcRearInp13-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp14-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp14")
   field(ZNAM, "Clear")
@@ -677,7 +677,7 @@ record(bo, "$(P)TrigSrcRearInp14-Sel") {
 }
 
 record(bo, "$(P)TrigSrcRearInp15-Sel") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVG TrigEvt")
   field(OUT , "#C0 S$(trigEvtNum) @$(EVG):RearInp15")
   field(ZNAM, "Clear")
@@ -706,7 +706,7 @@ record(bo, "$(P)Omsl-Sel") {
 }
 
 record(dfanout, "$(P)Omsl-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)Omsl0-FOut_ PP")
   field(OUTB, "$(P)Omsl1-FOut_ PP")
@@ -717,7 +717,7 @@ record(dfanout, "$(P)Omsl-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl0-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcMxc0-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcMxc1-Sel.OMSL")
@@ -730,7 +730,7 @@ record(dfanout, "$(P)Omsl0-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl1-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcAC-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcFrontInp0-Sel.OMSL")
@@ -743,7 +743,7 @@ record(dfanout, "$(P)Omsl1-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl2-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcUnivInp4-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcUnivInp5-Sel.OMSL")
@@ -756,7 +756,7 @@ record(dfanout, "$(P)Omsl2-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl3-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcUnivInp12-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcUnivInp13-Sel.OMSL")
@@ -769,7 +769,7 @@ record(dfanout, "$(P)Omsl3-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl4-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcRearInp4-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcRearInp5-Sel.OMSL")
@@ -782,7 +782,7 @@ record(dfanout, "$(P)Omsl4-FOut_") {
 }
 
 record(dfanout, "$(P)Omsl5-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(OMSL, "closed_loop")
   field(OUTA, "$(P)TrigSrcRearInp12-Sel.OMSL")
   field(OUTB, "$(P)TrigSrcRearInp13-Sel.OMSL")

--- a/evgMrmApp/Db/evgUserEvt.db
+++ b/evgMrmApp/Db/evgUserEvt.db
@@ -10,11 +10,12 @@
 #
 
 record(longout, "$(P)-Cmd") {
-  field(ASG , "OPERATOR")
+  field(ASG , "$(ASGOPERATOR=OPERATOR)")
   field(FLNK, "$(P)-Seq_")
 }
 
 record(seq, "$(P)-Seq_") {
+  field(ASG,  "$(ASGPRIVATE=private)")
   # Trigger soft event
   field(DOL1, "$(CODE)")
   field(LNK1, "$(SYS){$(D)-SoftEvt}EvtCode-SP PP")

--- a/evgMrmApp/Db/evm-fct.template
+++ b/evgMrmApp/Db/evm-fct.template
@@ -1,6 +1,6 @@
 
 record(mbbiDirect, "$(P)Link-Sts_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint16")
   field(INP, "@OBJ=$(OBJ), PROP=Status")
   field(SCAN, "1 second")

--- a/evgMrmApp/Db/evm-fct.template
+++ b/evgMrmApp/Db/evm-fct.template
@@ -159,6 +159,7 @@ record(longin, "$(P)ID-I") {
 # Delay compensation at the EVM level
 record(bo, "$(P)DC-Ena-Sel") {
   field(DESC, "Apply DC correction")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=DCUpMode")
   field(ZNAM, "Disable")
@@ -179,6 +180,7 @@ record(bi, "$(P)DC-Ena-RB") {
 
 record(ao, "$(P)DC-Tgt-SP") {
   field(DESC, "Desired total delay")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT, "@OBJ=$(OBJ), PROP=DCUpTarget")
   field(EGU, "ns")

--- a/evgMrmApp/Db/seq-masker.db
+++ b/evgMrmApp/Db/seq-masker.db
@@ -19,7 +19,7 @@ record(aSub, "$(N)") {
 
   field(NOA, "$(NELM)")
   field(NOB, "$(NWORD=1)")
-
+ 
   field(INPA, "$(INCODE=)")
   field(INPB, "$(INMASK=)")
 

--- a/evgMrmApp/Db/seq-repeater.db
+++ b/evgMrmApp/Db/seq-repeater.db
@@ -39,7 +39,7 @@ record(longout, "$(P)Mask$(s=:)Rep-SP") {
 
 
 record(aSub, "$(P)Rep-Calc_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Seq Repeat")
     # A - cycle length in ticks
   field(INPA, "$(CYCLELEN)")

--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -14,6 +14,7 @@
 #
 record(bo, "$(P)Ena-Sel") {
   field(DESC, "Master HW Enable")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")
   field(MASK, "1")
@@ -35,6 +36,7 @@ record(longin, "$(P)Cnt$(s=:)LinkTimo-I") {
 }
 
 record(bo, "$(P)ExtInhib-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=External Inhibit")
   field(PINI, "YES")
@@ -135,6 +137,7 @@ record(calcout, "$(P)Link$(s=:)Init-FO_") {
 #
 # This must be close enough to the EVG master oscilator to allow the phase locked loop in the EVR to lock.
 record(ao, "$(P)Link$(s=:)Clk-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Clock")
   field(PINI, "YES")
@@ -154,6 +157,7 @@ record(ao, "$(P)Link$(s=:)Clk-SP") {
 
 record(bo,"$(P)ResetFracSynth-Cmd" ) {
   field(DESC, "Reset button")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop command")
   field(OUT , "@OBJ=$(OBJ), PROP=Reset Frac Synth")
   field(ZNAM, "Reset")
@@ -337,6 +341,7 @@ record(bi, "$(P)Time$(s=:)Valid-Sts") {
 }
 
 record(mbbo, "$(P)Time$(s=:)Src-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)Time$(s=:)Src-Sel_")
   field(PINI, "YES")
@@ -388,6 +393,7 @@ record(longout, "$(P)Time$(s=:)Src-Sel_") {
 # to read back the actual divider setting via the "Timestamp Prescaler" property.
 #
 record(ao, "$(P)Time$(s=:)Clock-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Timestamp Clock")
   field(DESC, "Timestamp frequency")
@@ -452,6 +458,7 @@ record(stringin, "$(P)Time-I") {
 #
 record(bo, "$(P)Link$(s=:)RxMode-Sel") {
   field(DESC, "Downstream data mode")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ):BUFRX, PROP=Enable")
   field(PINI, "YES")
@@ -469,6 +476,7 @@ record(waveform, "$(P)Label-I") {
 }
 
 record(mbbo, "$(P)PLL-Bandwidth-Sel") {
+    field( ASG,  "$(ASGPROTECTED=protected)")
     field( DESC, "EVR Evt Clock Bandwidth")
     field( DTYP, "Obj Prop uint16")
     field( OUT,  "@OBJ=$(OBJ), PROP=PLL Bandwidth")

--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -121,7 +121,7 @@ record(longin, "$(P)Cnt$(s=:)SwOflw-I") {
 # Detect the first time the event link
 # is online.  Then set master enable.
 record(calcout, "$(P)Link$(s=:)Init-FO_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Detect initial link up")
   field(INPA, "$(P)Link-Sts")
   field(CALC, "A")
@@ -308,7 +308,7 @@ record(stringin, "$(P)Pos-I") {
 }
 
 record(fanout, "$(P)Time$(s=:)Init-FO_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(PINI, "YES")
   field(LNK1, "$(P)Time$(s=:)Clock-SP")
   field(LNK2, "$(P)Time$(s=:)Src-Sel")
@@ -372,7 +372,7 @@ record(mbbo, "$(P)Time$(s=:)Src-Sel") {
 # * DBus 4 Increments on the 0->1 transition of DBus bit #4.
 #
 record(longout, "$(P)Time$(s=:)Src-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Timestamp Source")
   field(FLNK, "$(P)Time$(s=:)Clock-I")

--- a/evrApp/Db/evrcml.db
+++ b/evrApp/Db/evrcml.db
@@ -6,6 +6,7 @@
 #  OBJ = devObj name
 
 record(bo, "$(ON)Ena-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=Enable")
   field(PINI, "YES")
@@ -17,6 +18,7 @@ record(bo, "$(ON)Ena-Sel") {
 }
 
 record(bo, "$(ON)Pwr-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=Power")
   field(PINI, "YES")
@@ -28,6 +30,7 @@ record(bo, "$(ON)Pwr-Sel") {
 }
 
 record(bo, "$(ON)Rst-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=Reset")
   field(PINI, "YES")
@@ -51,6 +54,7 @@ record(bo, "$(ON)Rst-Sel") {
 # Waveform
 #   Uses the bit pattern stored by the Pattern Set property.
 record(mbbo, "$(ON)Mode-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "CML/GTX pattern mode")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=Mode")
@@ -112,6 +116,7 @@ record(fanout, "$(ON)Res-FO_") {
 # Send in 4x Pattern mode when output goes Inactive -> Active
 
 record(mbboDirect, "$(ON)Pat$(s=:)Rise00_15-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 0-15")
   field(NOBT, "16")
@@ -121,6 +126,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Rise00_15-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Rise16_31-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 16-31")
   field(NOBT, "16")
@@ -130,6 +136,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Rise16_31-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Rise32_39-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 32-39")
   field(NOBT, "16")
@@ -152,6 +159,7 @@ record(aSub, "$(ON)Pat$(s=:)Rise-ASub_") {
 }
 
 record(waveform, "$(ON)Pat$(s=:)Rise-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Rising edge pattern")
   field(DTYP, "Obj Prop waveform out")
   field(INP, "@OBJ=$(OBJ), PROP=Pat Rise")
@@ -167,6 +175,7 @@ record(waveform, "$(ON)Pat$(s=:)Rise-SP") {
 # # Send in 4x Pattern mode when output remain Active -> Active
 
 record(mbboDirect, "$(ON)Pat$(s=:)High00_15-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 0-15")
   field(NOBT, "16")
@@ -176,6 +185,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)High00_15-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)High16_31-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 16-31")
   field(NOBT, "16")
@@ -185,6 +195,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)High16_31-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)High32_39-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 32-39")
   field(NOBT, "16")
@@ -207,6 +218,7 @@ record(aSub, "$(ON)Pat$(s=:)High-ASub_") {
 }
 
 record(waveform, "$(ON)Pat$(s=:)High-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Rising edge pattern")
   field(DTYP, "Obj Prop waveform out")
   field(INP, "@OBJ=$(OBJ), PROP=Pat High")
@@ -222,6 +234,7 @@ record(waveform, "$(ON)Pat$(s=:)High-SP") {
 # Send in 4x Pattern mode when output goes Active -> Inactive
 
 record(mbboDirect, "$(ON)Pat$(s=:)Fall00_15-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 0-15")
   field(NOBT, "16")
@@ -231,6 +244,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Fall00_15-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Fall16_31-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 16-31")
   field(NOBT, "16")
@@ -240,6 +254,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Fall16_31-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Fall32_39-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 32-39")
   field(NOBT, "16")
@@ -263,6 +278,7 @@ record(aSub, "$(ON)Pat$(s=:)Fall-ASub_") {
 
 record(waveform, "$(ON)Pat$(s=:)Fall-SP") {
   field(DESC, "Rising edge pattern")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop waveform out")
   field(INP, "@OBJ=$(OBJ), PROP=Pat Fall")
   field(PINI, "YES")
@@ -277,6 +293,7 @@ record(waveform, "$(ON)Pat$(s=:)Fall-SP") {
 # Send in 4x Pattern mode when output remains Inactive -> Inactive
 
 record(mbboDirect, "$(ON)Pat$(s=:)Low00_15-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 0-15")
   field(NOBT, "16")
@@ -286,6 +303,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Low00_15-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Low16_31-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 16-31")
   field(NOBT, "16")
@@ -295,6 +313,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Low16_31-SP") {
 }
 
 record(mbboDirect, "$(ON)Pat$(s=:)Low32_39-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Soft and restore")
   field(DESC, "Bits 32-39")
   field(NOBT, "16")
@@ -318,6 +337,7 @@ record(aSub, "$(ON)Pat$(s=:)Low-ASub_") {
 
 record(waveform, "$(ON)Pat$(s=:)Low-SP") {
   field(DESC, "Rising edge pattern")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop waveform out")
   field(INP, "@OBJ=$(OBJ), PROP=Pat Low")
   field(PINI, "YES")
@@ -330,6 +350,7 @@ record(waveform, "$(ON)Pat$(s=:)Low-SP") {
 # frequency mode
 
 record(bo, "$(ON)Freq$(s=:)Lvl-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(DESC, "Trigger level")
   field(OUT, "@OBJ=$(OBJ), PROP=Freq Trig Lvl")
@@ -343,6 +364,7 @@ record(bo, "$(ON)Freq$(s=:)Lvl-SP") {
 
 record(ao, "$(ON)Freq$(s=:)Init-SP") {
   field(DESC, "Trigger point")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT, "@OBJ=$(OBJ), PROP=Counts Init")
   field(PINI, "YES")
@@ -368,6 +390,7 @@ record(longin, "$(ON)Freq$(s=:)Init-RB") {
 
 record(ao, "$(ON)Freq$(s=:)High-SP") {
   field(DESC, "Time active")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT, "@OBJ=$(OBJ), PROP=Counts High")
   field(PINI, "YES")
@@ -392,6 +415,7 @@ record(longin, "$(ON)Freq$(s=:)High-RB") {
 
 record(ao, "$(ON)Freq$(s=:)Low-SP") {
   field(DESC, "Time inactive")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT, "@OBJ=$(OBJ), PROP=Counts Low")
   field(PINI, "YES")
@@ -419,6 +443,7 @@ record(longin, "$(ON)Freq$(s=:)Low-RB") {
 
 record(bo, "$(ON)Pat$(s=:)WfCycle-SP") {
   field(DESC, "Waveform cycle mode")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=Pat Recycle")
   field(PINI, "YES")
@@ -432,6 +457,7 @@ record(bo, "$(ON)Pat$(s=:)WfCycle-SP") {
 
 record(waveform, "$(ON)Pat$(s=:)Wf-SP") {
   field(DESC, "Pattern setting")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop waveform out")
   field(INP, "@OBJ=$(OBJ), PROP=Waveform")
   field(PINI, "YES")
@@ -483,6 +509,7 @@ record(waveform, "$(ON)Pat$(s=:)WfX-I") {
 
 record(bo, "$(ON)WfCalc$(s=:)Ena-SP") {
   field(DESC, "Disable calculator")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(ONAM, "Enabled")
   field(ZNAM, "Disabled")
   field(UDF , "0")
@@ -490,6 +517,7 @@ record(bo, "$(ON)WfCalc$(s=:)Ena-SP") {
 }
 
 record(ao, "$(ON)WfCalc$(s=:)Delay-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(OUT , "$(ON)WfCalc-ASub_.A PP")
   field(EGU , "ns")
@@ -500,6 +528,7 @@ record(ao, "$(ON)WfCalc$(s=:)Delay-SP") {
 }
 
 record(ao, "$(ON)WfCalc$(s=:)Width-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(OUT , "$(ON)WfCalc-ASub_.B PP")
   field(EGU , "ns")
@@ -530,6 +559,7 @@ record(aSub, "$(ON)WfCalc-ASub_") {
 
 record(bo, "$(ON)BunchTrain$(s=:)Ena-SP") {
   field(DESC, "Disable calculator")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(ONAM, "Enabled")
   field(ZNAM, "Disabled")
   field(UDF , "0")
@@ -538,6 +568,7 @@ record(bo, "$(ON)BunchTrain$(s=:)Ena-SP") {
 }
 
 record(longout, "$(ON)BunchTrain$(s=:)Size-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(PINI, "YES")
   field(OUT , "$(ON)BunchTrain-ASub_.A PP")
   field(UDF , "0")

--- a/evrApp/Db/evrcml.db
+++ b/evrApp/Db/evrcml.db
@@ -98,7 +98,7 @@ record(calcout, "$(ON)Res-I") {
 }
 
 record(fanout, "$(ON)Res-FO_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Clock change resync")
   field(TSEL, "$(ON)Res-I.TIME")
   field(LNK1, "$(ON)Freq$(s=:)High-SP")
@@ -140,7 +140,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Rise32_39-SP") {
 }
 
 record(aSub, "$(ON)Pat$(s=:)Rise-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Bit Array Gen")
   field(BRSV, "INVALID")
   field(FTA, "USHORT")
@@ -195,7 +195,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)High32_39-SP") {
 }
 
 record(aSub, "$(ON)Pat$(s=:)High-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Bit Array Gen")
   field(BRSV, "INVALID")
   field(FTA, "USHORT")
@@ -250,7 +250,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Fall32_39-SP") {
 }
 
 record(aSub, "$(ON)Pat$(s=:)Fall-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Bit Array Gen")
   field(BRSV, "INVALID")
   field(FTA, "USHORT")
@@ -305,7 +305,7 @@ record(mbboDirect, "$(ON)Pat$(s=:)Low32_39-SP") {
 }
 
 record(aSub, "$(ON)Pat$(s=:)Low-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Bit Array Gen")
   field(BRSV, "INVALID")
   field(FTA, "USHORT")
@@ -456,7 +456,7 @@ record(waveform, "$(ON)Pat$(s=:)Wf-RB") {
 }
 
 record(aSub, "$(ON)Pat$(s=:)WfX-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Timeline")
   field(BRSV, "INVALID")
   field(INPA, "0")
@@ -510,7 +510,7 @@ record(ao, "$(ON)WfCalc$(s=:)Width-SP") {
 }
 
 record(aSub, "$(ON)WfCalc-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SDIS, "$(ON)WfCalc$(s=:)Ena-SP")
   field(DISV, "0")
   field(SNAM, "Delay Gen")
@@ -546,7 +546,7 @@ record(longout, "$(ON)BunchTrain$(s=:)Size-SP") {
 }
 
 record(aSub, "$(ON)BunchTrain-ASub_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SDIS, "$(ON)BunchTrain$(s=:)Ena-SP")
   field(DISV, "0")
   field(SNAM, "Bunch Train")

--- a/evrApp/Db/evrcmlgun.db
+++ b/evrApp/Db/evrcmlgun.db
@@ -6,6 +6,7 @@
 #  OBJ = devObj name
 
 record(ao, "$(ON)Delay-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Fine Delay")
   field(PINI, "YES")

--- a/evrApp/Db/evrevent-cycle.db
+++ b/evrApp/Db/evrevent-cycle.db
@@ -13,6 +13,7 @@
 # EVT  - Timing hardware event code
 # ENUM - EPICS DB event number
 record(longout, "$(P)Cnt$(s=:)$(C)-SP_") {
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVR Event")
   field(SCAN, "I/O Intr")
   field(OUT , "@OBJ=$(EVR),Code=$(CODE)")

--- a/evrApp/Db/evrevent.db
+++ b/evrApp/Db/evrevent.db
@@ -10,6 +10,7 @@
 # EVT  - Timing hardware event code
 # ENUM - EPICS DB event number
 record(longout, "$(EN)-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVR Event")
   field(SCAN, "I/O Intr")
   field(OUT , "@OBJ=$(OBJ),Code=$(CODE)")

--- a/evrApp/Db/evreventutag.db
+++ b/evrApp/Db/evreventutag.db
@@ -35,7 +35,7 @@ record(longout, "$(EN)Code-SP") {
 }
 
 record(printf, "$(EN)Code-Lock_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DISP, "1")
   field(FMT, "@OBJ=$(OBJ),Code=%u")
   field(INP0, "$(EN)Code-SP CPP")

--- a/evrApp/Db/evreventutag.db
+++ b/evrApp/Db/evreventutag.db
@@ -8,6 +8,7 @@
 #  CODE = Event code (hardware)
 
 record(int64out, "$(EN)-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVR Event Utag")
   field(SCAN, "I/O Intr")
   field(OUT , "@OBJ=$(OBJ),Code=$(CODE)")
@@ -27,6 +28,7 @@ record(calc, "$(EN)Cnt-I") {
 }
 
 record(longout, "$(EN)Code-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Event Code")
   field(VAL , "$(CODE=255)")
   field(PINI, "YES")

--- a/evrApp/Db/evrin.db
+++ b/evrApp/Db/evrin.db
@@ -8,6 +8,7 @@
 record(bo, "$(IN)Lvl-Sel") {
   field(DTYP, "Obj Prop bool")
   field(DESC, "Input $(DESC)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Active Level")
   field(PINI, "YES")
   field(VAL , "1")
@@ -27,6 +28,7 @@ record(bi, "$(IN)State-I") {
 }
 
 record(bo, "$(IN)Edge-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Active Edge")
   field(PINI, "YES")
@@ -37,6 +39,7 @@ record(bo, "$(IN)Edge-Sel") {
 }
 
 record(mbbo, "$(IN)Trig$(s=:)Ext-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=External Mode")
   field(PINI, "YES")
@@ -66,6 +69,7 @@ record(mbbo, "$(IN)Trig$(s=:)Ext-Sel") {
 
 # Sets code which will be applied to the local mapping ram whenever the 'External Mode' condition is met.
 record(longout, "$(IN)Code$(s=:)Ext-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=External Code")
   field(PINI, "YES")
@@ -79,6 +83,7 @@ record(longout, "$(IN)Code$(s=:)Ext-SP") {
 
 # Sets the code which will be sent on the upstream event link whenever the 'Backwards Mode' condition is met.
 record(mbbo, "$(IN)Trig$(s=:)Back-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=Backwards Mode")
   field(PINI, "YES")
@@ -107,6 +112,7 @@ record(mbbo, "$(IN)Trig$(s=:)Back-Sel") {
 }
 
 record(longout, "$(IN)Code$(s=:)Back-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Backwards Code")
   field(PINI, "YES")
@@ -119,6 +125,7 @@ record(longout, "$(IN)Code$(s=:)Back-SP") {
 }
 
 record(mbbo, "$(IN)DBus-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=DBus Mask")
   field(PINI, "YES")

--- a/evrApp/Db/evrmap.db
+++ b/evrApp/Db/evrmap.db
@@ -42,6 +42,7 @@
 #   Bypass the automatic allocation mechanism and always include this code in the event FIFO.
 #
 record(longout, "$(NAME)") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVR Mapping" )
   field(OUT , "@OBJ=$(OBJ), Func=$(func)")
   field(PINI, "YES")

--- a/evrApp/Db/evrout.db
+++ b/evrApp/Db/evrout.db
@@ -6,6 +6,7 @@
 #  DESC = Physical label found on output jack
 
 record(longout, "$(ON)Src-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "Output $(DESC)")
   field(OUT , "@OBJ=$(OBJ), PROP=Map")
@@ -20,6 +21,7 @@ record(longin, "$(ON)Src-RB") {
 }
 
 record(bo, "$(ON)Ena-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(DESC, "Output $(DESC)")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")

--- a/evrApp/Db/evrpulser.db
+++ b/evrApp/Db/evrpulser.db
@@ -15,6 +15,7 @@
 # before mapped actions take effect.
 #
 record(bo, "$(PN)Ena-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")
   field(PINI, "YES")
@@ -27,12 +28,14 @@ record(bo, "$(PN)Ena-Sel") {
 
 # Pulser Soft set/reset
 record(bo, "$(PN)Set-Cmd") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Soft set")
   field(DTYP, "Obj Prop command")
   field(OUT , "@OBJ=$(OBJ), PROP=SoftSet")
 }
 
 record(bo, "$(PN)Reset-Cmd") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Soft reset")
   field(DTYP, "Obj Prop command")
   field(OUT , "@OBJ=$(OBJ), PROP=SoftReset")
@@ -42,6 +45,7 @@ record(bo, "$(PN)Reset-Cmd") {
 # output from normally low to normally high.
 #
 record(bo, "$(PN)Polarity-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Polarity")
   field(PINI, "YES")
@@ -55,6 +59,7 @@ record(bo, "$(PN)Polarity-Sel") {
 # Determines the time between when the Pulse Generator is triggered
 # and when it changes state from inactive to active (normally low to high).
 record(ao, "$(PN)Delay-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Delay")
   field(PINI, "YES")
@@ -93,6 +98,7 @@ record(longin, "$(PN)Delay$(s=:)Raw-RB") {
 # inactive to active (normally low to high), and when it changes back to inactive.
 #
 record(ao, "$(PN)Width-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop double")
   field(OUT , "@OBJ=$(OBJ), PROP=Width")
   field(PINI, "YES")
@@ -132,6 +138,7 @@ record(longin, "$(PN)Width$(s=:)Raw-RB") {
 # Achieves greater range at the expense of resolution.
 #
 record(longout, "$(PN)Prescaler-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Prescaler")
   field(DESC, "Pulser prescaler")
@@ -183,6 +190,7 @@ record(waveform, "$(PN)Label-I") {
 # Triger pulser generator by one or more prescalers
 record(mbboDirect, "$(PN)PSTrig-Sel")
 {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=PSTrig")
   field(PINI, "YES")
@@ -204,6 +212,7 @@ record(mbbiDirect, "$(PN)PSTrig-RB")
 # Trigger pulser generator by one or more DBus bits
 record(mbboDirect, "$(PN)DBusTrig-Sel")
 {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=DBusTrig")
   field(PINI, "YES")

--- a/evrApp/Db/evrpulser.db
+++ b/evrApp/Db/evrpulser.db
@@ -167,7 +167,7 @@ record(calc, "$(PN)Res-I") {
 }
 
 record(fanout, "$(PN)Res-FO_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Clock change resync")
   field(LNK1, "$(PN)Delay-SP")
   field(LNK2, "$(PN)Width-SP")

--- a/evrApp/Db/evrpulsermap.db
+++ b/evrApp/Db/evrpulsermap.db
@@ -10,6 +10,7 @@
 #
 
 record(longout, "$(NAME)") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "EVR Pulser Mapping" )
   field(OUT , "@OBJ=$(OBJ), Func=$(F=Trig)")
   field(PINI, "YES")

--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -68,7 +68,7 @@ record(ao, "$(SN)PhasOffs-SP") {
 }
 
 record(calcout, "$(SN)PhasOffs-CO_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Degrees to Event Clock Ticks")
   field(OUT , "$(SN)PhasOffs$(s=:)Raw-SP PP")
   field(CALC, "FLOOR(B/360*A)")

--- a/evrApp/Db/evrscale.db
+++ b/evrApp/Db/evrscale.db
@@ -9,6 +9,7 @@
 
 record(bo, "$(P)PSPolarity-Sel")
 {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(DESC, "Polarity of all prescalers")
   field(OUT , "@OBJ=$(EVR), PROP=PSPolarity")
@@ -20,6 +21,7 @@ record(bo, "$(P)PSPolarity-Sel")
 }
 
 record(longout, "$(SN)Div-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "Prescaler $(IDX)")
   field(OUT , "@OBJ=$(OBJ), PROP=Divide")
@@ -41,6 +43,7 @@ record(longin, "$(SN)Div-RB") {
 }
 
 record(calc, "$(SN)Rate-I") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Output frequency")
   field(INPA, "$(SN)Div-RB NPP")
   field(INPB, "$(P)Link$(s=:)Clk-I CP")
@@ -57,6 +60,7 @@ record(waveform, "$(SN)Label-I") {
 }
 
 record(ao, "$(SN)PhasOffs-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Prescaler $(IDX) Phase Offset")
   field(EGU , "Deg")
   field(OMSL, "supervisory")
@@ -77,6 +81,7 @@ record(calcout, "$(SN)PhasOffs-CO_") {
 }
 
 record(longout, "$(SN)PhasOffs$(s=:)Raw-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "Prescaler $(IDX) Phase Offset")
   field(OUT , "@OBJ=$(OBJ), PROP=Phase Offset")

--- a/evrApp/Db/evrsoftgate.db
+++ b/evrApp/Db/evrsoftgate.db
@@ -21,6 +21,7 @@
 
 
 record(longout, "$(P)Evt$(s=:)Start-SP_") {
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "EVR Event")
   field(OUT, "@OBJ=$(OBJ),Code=$(Code)")
   field(VAL, "-1")
@@ -38,22 +39,26 @@ record(longout, "$(P)Evt$(s=:)Start-SP_") {
 
 record(bo, "$(P)Ena-Sel") {
   field(DESC, "Request burst")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(UDF, "0")
   field(ZNAM, "Idle")
   field(ONAM, "Request Burst")
 }
 
 record(ao, "$(P)Delay-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(EGU, "us")
   info(autosaveFields_pass0, "VAL")
 }
 
 record(ao, "$(P)Width-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(EGU, "us")
   info(autosaveFields_pass0, "VAL")
 }
 
 record(seq, "$(P)Evt$(s=:)1-Seq_") {
+  field(ASG, "$(ASGPRIVATE=private)")
   # First clear request
   field(DOL1, "0")
   field(LNK1, "$(P)Ena-Sel PP")
@@ -68,6 +73,7 @@ record(seq, "$(P)Evt$(s=:)1-Seq_") {
 }
 
 record(seq, "$(P)Evt$(s=:)2-Seq_") {
+  field(ASG, "$(ASGPRIVATE=private)")
   # wait DLY1
   # write 1 to enable output
   field(DOL1, "1")

--- a/evrFRIBApp/Db/fribevrout.db
+++ b/evrFRIBApp/Db/fribevrout.db
@@ -84,7 +84,7 @@ record(mbbo, "$(ON)Src$(s=:)Scale-SP") {
 # Mapping readback
 
 record(fanout, "$(ON)Src-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(LNK1, "$(ON)Src-RB_")
   field(LNK2, "$(ON)Src$(s=:)Pulse-RB")
   field(LNK3, "$(ON)Src$(s=:)DBus-RB")
@@ -93,7 +93,7 @@ record(fanout, "$(ON)Src-FOut_") {
 }
 
 record(longin, "$(ON)Src-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "$(DESC)")
   field(INP , "@OBJ=$(OBJ), PROP=Map")
@@ -146,7 +146,7 @@ record(mbbi, "$(ON)Src$(s=:)Scale-RB") {
 }
 
 record(aSub, "$(ON)Src-Calc_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(SNAM, "Select String")
   field(FTA , "STRING")
   field(FTB , "STRING")

--- a/evrMrmApp/Db/evrSoftEvt.template
+++ b/evrMrmApp/Db/evrSoftEvt.template
@@ -1,4 +1,5 @@
 record(longout, "$(P)EvtCode-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Sent software event")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=EvtCode")
@@ -34,6 +35,7 @@ record(mbbo, "$(P)SoftTimeSrc-Sel") {
 }
 
 record(bo,"$(P)SyncTimestamp-Cmd" ) {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop command")
   field(OUT , "@OBJ=$(OBJ), PROP=Sync TS")
   field(DESC, "EVG Sync TimeStamp")

--- a/evrMrmApp/Db/evrSoftSeq.template
+++ b/evrMrmApp/Db/evrSoftSeq.template
@@ -15,6 +15,7 @@ record(fanout, "$(P)TrigSrc$(s=:)Init-FOut_") {
 }
 
 record(mbbo, "$(P)TrigSrc$(s=:)Pulse-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(ZRST, "Pulser 0")
@@ -54,6 +55,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)Pulse-Sel") {
 }
 
 record(mbbo, "$(P)TrigSrc$(s=:)DBus-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(ZRST, "DBus0")
@@ -77,6 +79,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)DBus-Sel") {
 }
 
 record(mbbo, "$(P)TrigSrc$(s=:)Scale-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
   field(ZRST, "None")

--- a/evrMrmApp/Db/evrSoftSeq.template
+++ b/evrMrmApp/Db/evrSoftSeq.template
@@ -10,7 +10,7 @@
 # linked from mrmSoftSeq.template
 # $(P)InitSeq$(s=:)Cont-FOut_
 record(fanout, "$(P)TrigSrc$(s=:)Init-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(LNK1, "$(P)TrigSrc-Sel_")
 }
 
@@ -104,7 +104,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)Scale-Sel") {
 }
 
 record(longout, "$(P)TrigSrc-Sel_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TRIG_SRC")
   field(VAL , "0x03000000") # default to None
@@ -112,7 +112,7 @@ record(longout, "$(P)TrigSrc-Sel_") {
 }
 
 record(longin, "$(P)TrigSrc-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(INP , "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TRIG_SRC")
   field(UDF,  "0")

--- a/evrMrmApp/Db/evrdcpulser.template
+++ b/evrMrmApp/Db/evrdcpulser.template
@@ -1,4 +1,5 @@
 record(mbboDirect, "$(PN)Mask-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Masks")
   field(PINI, "YES")
@@ -17,6 +18,7 @@ record(mbbiDirect, "$(PN)Mask-RB") {
 }
 
 record(mbboDirect, "$(PN)EnableGate-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT , "@OBJ=$(OBJ), PROP=Enables")
   field(PINI, "YES")

--- a/evrMrmApp/Db/mrmevrbase.template
+++ b/evrMrmApp/Db/mrmevrbase.template
@@ -3,6 +3,7 @@ include "evrbase.db"
 
 
 record(mbbo, "$(P)Src$(s=:)Clk-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(OBJ), PROP=Clock Mode")
   field(PINI, "YES")

--- a/evrMrmApp/Db/mrmevrdc.template
+++ b/evrMrmApp/Db/mrmevrdc.template
@@ -1,6 +1,7 @@
 # Delay Compensation control/status
 
 record(bo, "$(P)Ena-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Apply DC correction")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=DCEnable")
@@ -20,6 +21,7 @@ record(bi, "$(P)Ena-RB") {
 }
 
 record(ao, "$(P)Tgt-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DESC, "Desired total delay")
   field(DTYP, "Obj Prop double")
   field(OUT, "@OBJ=$(OBJ), PROP=DCTarget")

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -385,7 +385,7 @@ record(mbbo, "$(ON)Src2$(s=:)Gate-SP") {
 # Mapping readback
 
 record(longin, "$(ON)Src-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "$(DESC)")
   field(INP , "@OBJ=$(OBJ), PROP=Map")
@@ -393,7 +393,7 @@ record(longin, "$(ON)Src-RB_") {
 }
 
 record(longin, "$(ON)Src2-RB_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
   field(DESC, "$(DESC)")
   field(INP , "@OBJ=$(OBJ), PROP=Map2")

--- a/evrMrmApp/Db/mrmevrout.db
+++ b/evrMrmApp/Db/mrmevrout.db
@@ -9,6 +9,7 @@
 record(bo, "$(ON)Ena-SP") {
   field(DTYP, "Obj Prop bool")
   field(DESC, "Output $(DESC)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")
   field(PINI, "YES")
   field(ZNAM, "Disabled")
@@ -20,6 +21,7 @@ record(bo, "$(ON)Ena-SP") {
 record(longout, "$(ON)Src-SP") {
   field(DTYP, "Obj Prop uint32")
   field(DESC, "$(DESC)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Map")
   field(FLNK, "$(ON)Src-RB_")
   field(PINI, "YES")
@@ -30,6 +32,7 @@ record(longout, "$(ON)Src-SP") {
 record(longout, "$(ON)Src2-SP") {
   field(DTYP, "Obj Prop uint32")
   field(DESC, "$(DESC)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT , "@OBJ=$(OBJ), PROP=Map2")
   field(FLNK, "$(ON)Src2-RB_")
   field(PINI, "YES")
@@ -41,6 +44,7 @@ record(longout, "$(ON)Src2-SP") {
 # Users use will set one of these at a time.
 
 record(mbbo, "$(ON)Src$(s=:)Pulse-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src-SP PP")
   field(ZRST, "Pulser 0")
@@ -81,6 +85,7 @@ record(mbbo, "$(ON)Src$(s=:)Pulse-SP") {
 }
 
 record(mbbo, "$(ON)Src$(s=:)Pulse2-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src-SP PP")
   field(ZRST, "Pulser 16")
@@ -113,6 +118,7 @@ record(mbbo, "$(ON)Src$(s=:)Pulse2-SP") {
 }
 
 record(mbbo, "$(ON)Src2$(s=:)Pulse-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src2-SP PP")
   field(ZRST, "Pulser 0")
@@ -153,6 +159,7 @@ record(mbbo, "$(ON)Src2$(s=:)Pulse-SP") {
 }
 
 record(mbbo, "$(ON)Src2$(s=:)Pulse2-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src2-SP PP")
   field(ZRST, "Pulser 16")
@@ -185,6 +192,7 @@ record(mbbo, "$(ON)Src2$(s=:)Pulse2-SP") {
 }
 
 record(mbbo, "$(ON)Src$(s=:)DBus-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src-SP PP")
   field(ZRST, "DBus 0")
@@ -217,6 +225,7 @@ record(mbbo, "$(ON)Src$(s=:)DBus-SP") {
 }
 
 record(mbbo, "$(ON)Src2$(s=:)DBus-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src2-SP PP")
   field(ZRST, "DBus 0")
@@ -249,6 +258,7 @@ record(mbbo, "$(ON)Src2$(s=:)DBus-SP") {
 }
 
 record(mbbo, "$(ON)Src$(s=:)Scale-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src-SP PP")
   field(ZRST, "Prescaler 0")
@@ -281,6 +291,7 @@ record(mbbo, "$(ON)Src$(s=:)Scale-SP") {
 }
 
 record(mbbo, "$(ON)Src2$(s=:)Scale-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src2-SP PP")
   field(ZRST, "Prescaler 0")
@@ -313,6 +324,7 @@ record(mbbo, "$(ON)Src2$(s=:)Scale-SP") {
 }
 
 record(mbbo, "$(ON)Src$(s=:)Gate-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src-SP PP")
   field(ZRST, "Flip-flop 0")
@@ -348,6 +360,7 @@ record(mbbo, "$(ON)Src$(s=:)Gate-SP") {
 }
 
 record(mbbo, "$(ON)Src2$(s=:)Gate-SP") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(ON)Src2-SP PP")
   field(ZRST, "Flip-flop 0")

--- a/evrMrmApp/Db/mrmevroutdly.db
+++ b/evrMrmApp/Db/mrmevroutdly.db
@@ -2,6 +2,7 @@
 # This file depreciates the mrmevrdlymodule.template
 
 record(ao, "$(ON)FineDelay-SP") {
+  field( ASG,  "$(ASGPROTECTED=protected)")
   field( DESC, "Fine delay output")
   field( DTYP, "Obj Prop double")
   field( OUT , "@OBJ=$(OBJ), PROP=Fine Delay")

--- a/evrMrmApp/Db/mrmevrtsbuf.db
+++ b/evrMrmApp/Db/mrmevrtsbuf.db
@@ -34,6 +34,7 @@ record(waveform, "$(P)TS-I") {
 
 record(longout, "$(P)CptEvt-SP") {
   field(DESC, "$(DESC=)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=TimeEvent")
   field(VAL , "$(CODE=0)")
@@ -50,6 +51,7 @@ record(longin, "$(P)CptEvt-RB") {
 
 record(longout, "$(P)FlshEvt-SP") {
   field(DESC, "$(DESC=)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint16")
   field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushEvent")
   field(VAL , "$(TRIG=0)")
@@ -66,6 +68,7 @@ record(longin, "$(P)FlshEvt-RB") {
 
 record(bo, "$(P)Flsh-SP") {
   field(DESC, "$(DESC=)")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop command")
   field(OUT , "@OBJ=$(NAME=$(EVR):CPT$(CODE)), CLASS=EVRMRMTSBuffer, PARENT=$(EVR), PROP=FlushManual")
   field(VAL , "$(TRIG=0)")

--- a/mrmShared/Db/databuftx.db
+++ b/mrmShared/Db/databuftx.db
@@ -1,6 +1,7 @@
 
 record(waveform, "$(P)dbus$(s=:)send$(s=:)s8") {
   field(DESC, "Send Buffer")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "MRF Data Buf Tx")
   field(INP , "@OBJ=$(OBJ), Proto=$(PROTO), P=Data Tx")
   field(FTVL, "CHAR")
@@ -11,6 +12,7 @@ record(waveform, "$(P)dbus$(s=:)send$(s=:)s8") {
 
 record(waveform, "$(P)dbus$(s=:)send$(s=:)u32") {
   field(DESC, "Send Buffer")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "MRF Data Buf Tx")
   field(INP , "@OBJ=$(OBJ), Proto=$(PROTO), P=Data Tx")
   field(FTVL, "ULONG")

--- a/mrmShared/Db/databuftxCtrl.db
+++ b/mrmShared/Db/databuftxCtrl.db
@@ -7,6 +7,7 @@
 #
 record(bo, "$(P)Link$(s=:)TxMode-Sel") {
   field(DESC, "Data mode")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT , "@OBJ=$(OBJ), PROP=Enable")
   field(PINI, "YES")

--- a/mrmShared/Db/mrmSoftSeq.template
+++ b/mrmShared/Db/mrmSoftSeq.template
@@ -336,7 +336,7 @@ record(longin, "$(P)NumOfRuns-I") {
 #
 
 record(calcout, "$(P)Load-Calc_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(CALC, "A")
   field(INPA, "$(P)Load-RB NPP NMS")
   field(OOPT, "When Non-zero")
@@ -348,7 +348,7 @@ record(calcout, "$(P)Load-Calc_") {
 #
 
 record(calcout, "$(P)Commit-Calc_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(CALC, "A")
   field(INPA, "$(P)Commit-RB NPP NMS")
   field(OOPT, "When Non-zero")
@@ -360,7 +360,7 @@ record(calcout, "$(P)Commit-Calc_") {
 #
 
 record(calcout, "$(P)Enable-Calc_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(CALC, "A")
   field(INPA, "$(P)Enable-RB NPP NMS")
   field(OOPT, "When Non-zero")
@@ -368,7 +368,7 @@ record(calcout, "$(P)Enable-Calc_") {
 }
 
 record(fanout, "$(P)InitSeq-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Boot of sequence for sequencer")
   field(SELM, "All")
   field(PINI, "RUNNING")
@@ -381,7 +381,7 @@ record(fanout, "$(P)InitSeq-FOut_") {
 }
 
 record(fanout, "$(P)InitSeq$(s=:)Cont-FOut_") {
-  field(ASG, "private")
+  field(ASG, "$(ASGPRIVATE=private)")
   field(DESC, "Boot of sequence for sequencer")
   field(SELM, "All")
   field(LNK1, "$(P)TrigSrc$(s=:)Init-FOut_")

--- a/mrmShared/Db/mrmSoftSeq.template
+++ b/mrmShared/Db/mrmSoftSeq.template
@@ -6,6 +6,7 @@
 # Device indpendent parts of sequencer (excludes trigger source mapping)
 
 record(mbbo, "$(P)TsResolution-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TIMEUNITS")
   field(ZRST, "Ticks")
@@ -63,6 +64,7 @@ record(mbbi, "$(P)TsResolution-RB") {
 record(waveform, "$(P)EvtEna-SP") {
   field(DTYP, "Obj Prop waveform out")
   field(DESC, "Sequence event enable array")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(INP,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=ENA")
   field(NELM, "$(NELM)")
   field(FTVL, "UCHAR")
@@ -81,6 +83,7 @@ record(waveform, "$(P)EvtEna-RB") {
 record(waveform, "$(P)EvtMask-SP") {
   field(DTYP, "Obj Prop waveform out")
   field(DESC, "Sequence event mask array")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(INP,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=MASK")
   field(NELM, "$(NELM)")
   field(FTVL, "UCHAR")
@@ -99,6 +102,7 @@ record(waveform, "$(P)EvtMask-RB") {
 record(waveform, "$(P)EvtCode-SP") {
   field(DTYP, "Obj Prop waveform out")
   field(DESC, "Sequence event code array")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(INP,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=CODES")
   field(NELM, "$(NELM)")
   field(FTVL, "UCHAR")
@@ -117,6 +121,7 @@ record(waveform, "$(P)EvtCode-RB") {
 record(waveform, "$(P)Timestamp-SP") {
   field(DTYP, "Obj Prop waveform out")
   field(DESC, "Sequence timestamp array")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(INP,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=TIMES")
   field(NELM, "$(NELM)")
   field(FTVL, "DOUBLE")
@@ -133,6 +138,7 @@ record(waveform, "$(P)Timestamp-RB") {
 }
 
 record(mbbo, "$(P)RunMode-Sel") {
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop uint32")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=RUN_MODE")
   field(UDF,  "0")
@@ -189,6 +195,7 @@ record(mbbi, "$(P)RunMode-RB") {
 record(bo, "$(P)Commit-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "Commit EVG Sequence")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=COMMIT")
   field(VAL,  "1")
   field(UDF,  "0")
@@ -199,6 +206,7 @@ record(bo, "$(P)Commit-Cmd") {
 record(bo, "$(P)Load-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "ALLOC EVG Sequence")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=LOAD")
   field(VAL,  "1")
   field(UDF,  "0")
@@ -209,6 +217,7 @@ record(bo, "$(P)Load-Cmd") {
 record(bo, "$(P)Unload-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "Dealloc EVG Sequence")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=UNLOAD")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -219,6 +228,7 @@ record(bo, "$(P)Unload-Cmd") {
 record(bo, "$(P)Enable-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "Enable EVG Sequence")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=ENABLE")
   field(VAL,  "1")
   field(UDF,  "0")
@@ -231,6 +241,7 @@ record(bo, "$(P)Enable-Cmd") {
 record(bo, "$(P)Disable-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "Disable EVG Sequence")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=DISABLE")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -242,6 +253,7 @@ record(bo, "$(P)Disable-Cmd") {
 record(bo, "$(P)SoftTrig-Cmd") {
   field(DTYP, "Obj Prop command")
   field(DESC, "Sequence RAM soft trigger")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=SOFT_TRIG")
   field(VAL,  "0")
   field(UDF,  "0")
@@ -252,6 +264,7 @@ record(bo, "$(P)SoftTrig-Cmd") {
 record(mbbo, "$(P)SwMask-Sel") {
   field(DTYP, "Obj Prop uint32")
   field(DESC, "Sequence RAM soft trigger")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(NOBT, "4")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=SWMASK")
 }
@@ -266,6 +279,7 @@ record(mbbi, "$(P)SwMask-RB") {
 record(mbbo, "$(P)SwEna-Sel") {
   field(DTYP, "Obj Prop uint32")
   field(DESC, "Sequence RAM soft trigger")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(NOBT, "4")
   field(OUT,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=SWENA")
 }
@@ -300,6 +314,7 @@ record(bi, "$(P)Commit-RB") {
 record(bi, "$(P)Enable-Sts") {
   field(DTYP, "Obj Prop bool")
   field(DESC, "Soft Seq Ena status")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(INP,  "@OBJ=$(EVG):SEQ$(seqNum), CLASS=SeqManager, PARENT=$(EVG):SEQMGR, PROP=ENABLED")
   field(SCAN, "I/O Intr")
   field(ZNAM, "Disabled")


### PR DESCRIPTION
Assuming PVs ending with _ are private PVs (which should not be changed outside the IOC) and protected PVs are PVs which can change the behavior of EVR/EVG this MR will set all private PVs with ASG=$(ASGPRIVATE=private) and the protected PVs with ASG=$(ASGPROTECTED=protected).
The use of macros will allow also usage of different ASG names.