### PR TITLE
feat: add DC port status within EVMs

### DIFF
--- a/evgMrmApp/Db/evm-fct.template
+++ b/evgMrmApp/Db/evm-fct.template
@@ -150,51 +150,51 @@ record(ai, "$(P)Msrd$(s=:)8-I") {
   field(PREC, "3")
 }
 
-record(longin, "$(P)DCPort1-Sts") {
+record(longin, "$(P)DCStatus1-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus1")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus1")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort2-Sts") {
+record(longin, "$(P)DCStatus2-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus2")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus2")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort3-Sts") {
+record(longin, "$(P)DCStatus3-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus3")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus3")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort4-Sts") {
+record(longin, "$(P)DCStatus4-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus4")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus4")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort5-Sts") {
+record(longin, "$(P)DCStatus5-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus5")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus5")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort6-Sts") {
+record(longin, "$(P)DCStatus6-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus6")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus6")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort7-Sts") {
+record(longin, "$(P)DCStatus7-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus7")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus7")
   field(SCAN, "1 second")
 }
 
-record(longin, "$(P)DCPort8-Sts") {
+record(longin, "$(P)DCStatus8-I") {
   field(DTYP, "Obj Prop uint32")
-  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus8")
+  field(INP, "@OBJ=$(OBJ), PROP=DCStatus8")
   field(SCAN, "1 second")
 }
 

--- a/evgMrmApp/Db/evm-fct.template
+++ b/evgMrmApp/Db/evm-fct.template
@@ -150,6 +150,54 @@ record(ai, "$(P)Msrd$(s=:)8-I") {
   field(PREC, "3")
 }
 
+record(longin, "$(P)DCPort1-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus1")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort2-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus2")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort3-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus3")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort4-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus4")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort5-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus5")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort6-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus6")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort7-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus7")
+  field(SCAN, "1 second")
+}
+
+record(longin, "$(P)DCPort8-Sts") {
+  field(DTYP, "Obj Prop uint32")
+  field(INP, "@OBJ=$(OBJ), PROP=DCPortStatus8")
+  field(SCAN, "1 second")
+}
+
 record(longin, "$(P)ID-I") {
   field(DTYP, "Obj Prop uint32")
   field(INP, "@OBJ=$(OBJ), PROP=TopoID")

--- a/evgMrmApp/src/fct.cpp
+++ b/evgMrmApp/src/fct.cpp
@@ -121,12 +121,12 @@ OBJECT_BEGIN(FCT)
     OBJECT_PROP1("DCPort6", &FCT::dcPort<5>);
     OBJECT_PROP1("DCPort7", &FCT::dcPort<6>);
     OBJECT_PROP1("DCPort8", &FCT::dcPort<7>);
-    OBJECT_PROP1("DCPortStatus1", &FCT::dcPortStatus<0>);
-    OBJECT_PROP1("DCPortStatus2", &FCT::dcPortStatus<1>);
-    OBJECT_PROP1("DCPortStatus3", &FCT::dcPortStatus<2>);
-    OBJECT_PROP1("DCPortStatus4", &FCT::dcPortStatus<3>);
-    OBJECT_PROP1("DCPortStatus5", &FCT::dcPortStatus<4>);
-    OBJECT_PROP1("DCPortStatus6", &FCT::dcPortStatus<5>);
-    OBJECT_PROP1("DCPortStatus7", &FCT::dcPortStatus<6>);
-    OBJECT_PROP1("DCPortStatus8", &FCT::dcPortStatus<7>);
+    OBJECT_PROP1("DCStatus1", &FCT::dcPortStatus<0>);
+    OBJECT_PROP1("DCStatus2", &FCT::dcPortStatus<1>);
+    OBJECT_PROP1("DCStatus3", &FCT::dcPortStatus<2>);
+    OBJECT_PROP1("DCStatus4", &FCT::dcPortStatus<3>);
+    OBJECT_PROP1("DCStatus5", &FCT::dcPortStatus<4>);
+    OBJECT_PROP1("DCStatus6", &FCT::dcPortStatus<5>);
+    OBJECT_PROP1("DCStatus7", &FCT::dcPortStatus<6>);
+    OBJECT_PROP1("DCStatus8", &FCT::dcPortStatus<7>);
 OBJECT_END(FCT)

--- a/evgMrmApp/src/fct.cpp
+++ b/evgMrmApp/src/fct.cpp
@@ -19,6 +19,7 @@
 #define U32_UpDCMode 0x24
 #define U32_TOPID 0x2c
 #define U32_PortNDCValue(N) (0x40 +(N)*4)
+#define U32_PortNDCStatus(N) (0x140 +(N)*4)
 
 FCT::FCT(evgMrm *evg, const std::string& id, volatile epicsUInt8* const base)
     :mrf::ObjectInst<FCT>(id)
@@ -99,6 +100,11 @@ double FCT::dcPortN(unsigned port) const
     return READ32(base, PortNDCValue(port))/65536.0*period;
 }
 
+epicsUInt32 FCT::dcPortNStatus(unsigned port) const
+{
+    return READ32(base, PortNDCStatus(port));
+}
+
 OBJECT_BEGIN(FCT)
     OBJECT_PROP1("Status", &FCT::statusRaw);
     OBJECT_PROP1("DCUpstream", &FCT::dcUpstream);
@@ -115,4 +121,12 @@ OBJECT_BEGIN(FCT)
     OBJECT_PROP1("DCPort6", &FCT::dcPort<5>);
     OBJECT_PROP1("DCPort7", &FCT::dcPort<6>);
     OBJECT_PROP1("DCPort8", &FCT::dcPort<7>);
+    OBJECT_PROP1("DCPortStatus1", &FCT::dcPortStatus<0>);
+    OBJECT_PROP1("DCPortStatus2", &FCT::dcPortStatus<1>);
+    OBJECT_PROP1("DCPortStatus3", &FCT::dcPortStatus<2>);
+    OBJECT_PROP1("DCPortStatus4", &FCT::dcPortStatus<3>);
+    OBJECT_PROP1("DCPortStatus5", &FCT::dcPortStatus<4>);
+    OBJECT_PROP1("DCPortStatus6", &FCT::dcPortStatus<5>);
+    OBJECT_PROP1("DCPortStatus7", &FCT::dcPortStatus<6>);
+    OBJECT_PROP1("DCPortStatus8", &FCT::dcPortStatus<7>);
 OBJECT_END(FCT)

--- a/evgMrmApp/src/fct.h
+++ b/evgMrmApp/src/fct.h
@@ -40,10 +40,16 @@ public:
     epicsUInt32 topoId() const;
 
     double dcPortN(unsigned port) const;
+    epicsUInt32 dcPortNStatus(unsigned port) const;
 
     template<int port>
     double dcPort() const {
         return dcPortN(port);
+    }
+
+    template<int port>
+    epicsUInt32 dcPortStatus() const {
+        return dcPortNStatus(port);
     }
 };
 


### PR DESCRIPTION
The quality of the delay value: 
* 1 - initial lock, 
* 3 - locked with precision < event clock cycle, 
* 7 - fine precision.

I think alarms or other extensions can be added in other PRs.