### PR TITLE
fix: Fifo rst init required for newer FPGA images

### DIFF
--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -524,8 +524,8 @@ record(mbbi, "$(P)PLL-Bandwidth-RB") {
     field( FRVL, "4")
 }
 
-record(bo, "$(P)ResetFIFO") {
-  field(DESC, "Apply DC correction")
+record(bo, "$(P)FifoReset-Cmd") {
+  field(DESC, "Reset Event FIFO")
   field(DTYP, "Obj Prop bool")
-  field(OUT, "@OBJ=$(OBJ), PROP=RESETFifo")
+  field(OUT, "@OBJ=$(OBJ), PROP=FifoReset")
 }

--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -523,3 +523,9 @@ record(mbbi, "$(P)PLL-Bandwidth-RB") {
     field( THVL, "3")
     field( FRVL, "4")
 }
+
+record(bo, "$(P)ResetFIFO") {
+  field(DESC, "Apply DC correction")
+  field(DTYP, "Obj Prop bool")
+  field(OUT, "@OBJ=$(OBJ), PROP=RESETFifo")
+}

--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -526,6 +526,9 @@ record(mbbi, "$(P)PLL-Bandwidth-RB") {
 
 record(bo, "$(P)FifoReset-Cmd") {
   field(DESC, "Reset Event FIFO")
+  field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Obj Prop bool")
   field(OUT, "@OBJ=$(OBJ), PROP=FifoReset")
+  field(ZNAM, "Reset")
+  field(ONAM, "Reset")
 }

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1309,6 +1309,9 @@ EVRMRM::drain_fifo()
 
     SCOPED_LOCK2(evrLock, guard);
 
+    // Reset fifo when IOC starts
+    BITSET(NAT,32, base, Control, Control_fiforst);
+
     while(true) {
         int msg, err;
 
@@ -1424,6 +1427,11 @@ EVRMRM::drain_fifo()
             // clear fifo if link lost or buffer overflow
             BITSET(NAT,32, base, Control, Control_fiforst);
         }
+
+        // if (status&(IRQ_LinkChg)) {
+        //     // clear fifo if Link state change
+        //     BITSET(NAT,32, base, Control, Control_fiforst);
+        // }
 
         int iflags=epicsInterruptLock();
 

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1012,7 +1012,7 @@ EVRMRM::fifoResetGet() const
 void
 EVRMRM::fifoResetSet(bool v)
 {
-    printf("Command: Reset Event FIFO.\n");
+    printf("EVR(Command): Reset Event FIFO.\n");
     BITSET(NAT,32, base, Control, Control_fiforst);
 }
 
@@ -1440,14 +1440,8 @@ EVRMRM::drain_fifo()
         if (status&(IRQ_FIFOFull|IRQ_RXErr)) {
             // clear fifo if link lost or buffer overflow
             BITSET(NAT,32, base, Control, Control_fiforst);
-            printf("Reset Event FIFO.\n");
+            printf("EVR(IRQ_FIFOFull|IRQ_RXErr): Reset Event FIFO (status=0x%08)\n", status);
         }
-
-        // Never enters
-        // if (status&(IRQ_LinkChg)) {
-        //     // clear fifo if Link state change
-        //     BITSET(NAT,32, base, Control, Control_fiforst);
-        // }
 
         int iflags=epicsInterruptLock();
 

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1003,17 +1003,16 @@ EVRMRM::dcEnable(bool v)
         BITCLR32(base, Control, Control_DCEna);
 }
 
-
 bool
-EVRMRM::resetfifoRB() const
+EVRMRM::fifoResetGet() const
 {
-    return 1;
+    return true;
 }
 
 void
-EVRMRM::resetfifo(bool v)
+EVRMRM::fifoResetSet(bool v)
 {
-    printf("\n\n\n RESETING FIFO -- function \n\n\n ");
+    printf("Command: Reset Event FIFO.\n");
     BITSET(NAT,32, base, Control, Control_fiforst);
 }
 
@@ -1132,7 +1131,7 @@ void EVRMRM::setTimeSrc(epicsUInt32 raw)
 OBJECT_BEGIN2(EVRMRM, EVR)
   OBJECT_PROP2("Clock Mode", &EVRMRM::clockMode, &EVRMRM::clockModeSet);
   OBJECT_PROP2("DCEnable", &EVRMRM::dcEnabled, &EVRMRM::dcEnable);
-  OBJECT_PROP2("RESETFifo", &EVRMRM::resetfifoRB, &EVRMRM::resetfifo);
+  OBJECT_PROP2("FifoReset", &EVRMRM::fifoResetGet, &EVRMRM::fifoResetSet);
   OBJECT_PROP2("DCTarget", &EVRMRM::dcTarget, &EVRMRM::dcTargetSet);
   OBJECT_PROP1("DCRx",     &EVRMRM::dcRx);
   OBJECT_PROP1("DCInt",    &EVRMRM::dcInternal);
@@ -1441,9 +1440,10 @@ EVRMRM::drain_fifo()
         if (status&(IRQ_FIFOFull|IRQ_RXErr)) {
             // clear fifo if link lost or buffer overflow
             BITSET(NAT,32, base, Control, Control_fiforst);
-            printf("\n\n\n RESETING FIFO \n\n\n ");
+            printf("Reset Event FIFO.\n");
         }
 
+        // Never enters
         // if (status&(IRQ_LinkChg)) {
         //     // clear fifo if Link state change
         //     BITSET(NAT,32, base, Control, Control_fiforst);

--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -1003,6 +1003,20 @@ EVRMRM::dcEnable(bool v)
         BITCLR32(base, Control, Control_DCEna);
 }
 
+
+bool
+EVRMRM::resetfifoRB() const
+{
+    return 1;
+}
+
+void
+EVRMRM::resetfifo(bool v)
+{
+    printf("\n\n\n RESETING FIFO -- function \n\n\n ");
+    BITSET(NAT,32, base, Control, Control_fiforst);
+}
+
 double
 EVRMRM::dcTarget() const
 {
@@ -1118,6 +1132,7 @@ void EVRMRM::setTimeSrc(epicsUInt32 raw)
 OBJECT_BEGIN2(EVRMRM, EVR)
   OBJECT_PROP2("Clock Mode", &EVRMRM::clockMode, &EVRMRM::clockModeSet);
   OBJECT_PROP2("DCEnable", &EVRMRM::dcEnabled, &EVRMRM::dcEnable);
+  OBJECT_PROP2("RESETFifo", &EVRMRM::resetfifoRB, &EVRMRM::resetfifo);
   OBJECT_PROP2("DCTarget", &EVRMRM::dcTarget, &EVRMRM::dcTargetSet);
   OBJECT_PROP1("DCRx",     &EVRMRM::dcRx);
   OBJECT_PROP1("DCInt",    &EVRMRM::dcInternal);
@@ -1426,6 +1441,7 @@ EVRMRM::drain_fifo()
         if (status&(IRQ_FIFOFull|IRQ_RXErr)) {
             // clear fifo if link lost or buffer overflow
             BITSET(NAT,32, base, Control, Control_fiforst);
+            printf("\n\n\n RESETING FIFO \n\n\n ");
         }
 
         // if (status&(IRQ_LinkChg)) {

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -211,6 +211,10 @@ public:
 
     bool dcEnabled() const;
     void dcEnable(bool v);
+
+    bool resetfifoRB() const;
+    void resetfifo(bool v);
+
     double dcTarget() const;
     void dcTargetSet(double);
     //! Measured delay

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -212,8 +212,8 @@ public:
     bool dcEnabled() const;
     void dcEnable(bool v);
 
-    bool resetfifoRB() const;
-    void resetfifo(bool v);
+    bool fifoResetGet() const;
+    void fifoResetSet(bool v);
 
     double dcTarget() const;
     void dcTargetSet(double);


### PR DESCRIPTION
- tested with EVR img ver: 207.24
- add fifo reset command for expert usage