### PR TITLE
Flash : add Winbond chip information

### DIFF
--- a/mrfCommon/src/flash.cpp
+++ b/mrfCommon/src/flash.cpp
@@ -115,6 +115,20 @@ CFIFlash::readID(ID *id)
         }
     }
 
+    if(id->vendor==0xef) { // Winbond
+
+        id->vendorName = "Winbond";
+
+        switch(id->dev_type) {
+        case 0x60: // W25Q128JW-IQ/JQ 
+        case 0x80: // W25Q128JW-IM/JM
+            id->capacity = 1u<<(id->dev_id);
+            id->sectorSize = 16*1024u;
+            id->pageSize = 256;
+            break;
+        }
+    }
+
     // we only use 24-bit read/write/erase ops
     // so capacity beyond 16MB is not accessible.
     if(id->capacity>0x1000000)

--- a/mrfCommon/src/flash.cpp
+++ b/mrfCommon/src/flash.cpp
@@ -123,7 +123,7 @@ CFIFlash::readID(ID *id)
         case 0x60: // W25Q128JW-IQ/JQ 
         case 0x80: // W25Q128JW-IM/JM
             id->capacity = 1u<<(id->dev_id);
-            id->sectorSize = 16*1024u;
+            id->sectorSize = 64*1024u;
             id->pageSize = 256;
             break;
         }


### PR DESCRIPTION
Our latest mTCA-EVR-300 came up with an unsupported flash memory chip, sold by Winbond.

 I added the chip information to allow its flashing.
 
 Vendor documentation : https://www.winbond.com/resource-files/W25Q128JW_RevG_07292021%20Plus.pdf
 
 - Capacity : same computation as for Micron chips (although the W25Q128JW series only has 128 Mbit versions)
 
 - Sector and page size : 
 > The W25Q128JW array is organized into 65,536 programmable pages of 256-bytes each. Up to 256 bytes
can be programmed at a time. Pages can be erased in groups of 16 (4KB sector erase), groups of 128
(32KB block erase), groups of 256 (64KB block erase) or the entire chip (chip erase). The W25Q128JW
has 4,096 erasable sectors and 256 erasable blocks respectively

I first tried with sector size of 4 KB but it did not work. 64 KB proved to be the appropriate setting.

Unlike Micron chips, extra information such as serial number is not included in the standard `0x9f` SPI command. But it can apparently be retrieved with other commands. Do you think it would be nice to have ?