### PR TITLE
fix call to evrFastEvtRecv.template in substitutions

### DIFF
--- a/evrMrmApp/Db/evr-mtca-300.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300.substitutions
@@ -22,7 +22,7 @@ file "databuftx.db"
 
 file "evrFastEvtRecv.template"
 {
-{P="\$(P)", OBJ="$(EVR)"}
+{P="$(SYS){$(D)}", OBJ="$(EVR)"}
 }
 
 file "evrSoftEvt.template"

--- a/evrMrmApp/Db/evr-mtca-300u.substitutions
+++ b/evrMrmApp/Db/evr-mtca-300u.substitutions
@@ -34,7 +34,7 @@ file "databuftx.db"
 
 file "evrFastEvtRecv.template"
 {
-{P="\$(P)", OBJ="$(EVR)"}
+{P="\$(P)\$(ES)", OBJ="$(EVR)"}
 }
 
 file "evrSoftEvt.template"


### PR DESCRIPTION
Hi,

I'm fixing errors introduced by myself when implementing the Fast Event feature (#216) 

The various `.substitutions` are not all  using the same naming convention, but at least the instantiation of `evrFastEvtRecv.template` is correct in each file.