### PR TITLE
fix: pini field of trigevt and dbus src sel record

### DIFF
--- a/evgMrmApp/Db/evgDbus.db
+++ b/evgMrmApp/Db/evgDbus.db
@@ -3,7 +3,6 @@ record(mbbo, "$(P)Src-Sel") {
   field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)Src-Sel_ PP")
-  field(PINI, "RUNNING")
   field(VAL,  "0")
   field(ZRST, "Off")
   field(ONST, "Front0")
@@ -128,6 +127,7 @@ record(mbbo, "$(P)Src$(s=:)3-Sel") {
 record(longout, "$(P)Src-Sel_") {
   field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
+  field(PINI, "RUNNING")
   field(OUT , "@OBJ=$(OBJ), PROP=Source")
   field(VAL , "0") # default to None
   info(autosaveFields_pass0, "VAL")

--- a/evgMrmApp/Db/evgTrigEvt.db
+++ b/evgMrmApp/Db/evgTrigEvt.db
@@ -29,7 +29,6 @@ record(mbbo, "$(P)TrigSrc-Sel") {
   field(ASG,  "$(ASGPROTECTED=protected)")
   field(DTYP, "Raw Soft Channel")
   field(OUT , "$(P)TrigSrc-Sel_ PP")
-  field(PINI, "RUNNING")
   field(VAL,  "0")
   field(ZRST, "Off")
   field(ONST, "Mxc0")
@@ -168,6 +167,7 @@ record(mbbo, "$(P)TrigSrc$(s=:)3-Sel") {
 record(longout, "$(P)TrigSrc-Sel_") {
   field(ASG, "$(ASGPRIVATE=private)")
   field(DTYP, "Obj Prop uint32")
+  field(PINI, "RUNNING")
   field(OUT , "@OBJ=$(OBJ), PROP=Source")
   field(VAL , "0x03000000")
   info(autosaveFields_pass0, "VAL")


### PR DESCRIPTION
Following previous patch related to EVG Dbus and TrigEvt. The PINI field was incorrectly set to `$(P)TrigSrc-Sel` instead of `$(P)TrigSrc-Sel_`, which caused issues during autosave restoration. This patch corrects the problem.

### Test: 
#### Start an IOC with autosave and set TrigEvt and Dbus trigger source
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/16f7c01f-85a9-45ac-911c-58bad7a99f82" />

#### Restart IOC, autosave can restore previous setting value

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/42addba8-66fd-4f05-a2a0-878235557a39" />


The EVR register matches what we set
```shell
epics> pciread 32 0x540 0x50

0x00000000 00010000 00020000 00040000 00080000
0x00000010 00100000 00200000 00400000 00800000
0x00000020 00000000 00000000 00000000 00000000
0x00000030 00000000 00000000 00000000 00000004
0x00000040 00000020 00000000 00000000 00000000

```
