### PR TITLE
fix: avoid duplicate soft timestamp event 125

### DIFF
--- a/evgMrmApp/src/evgMrm.cpp
+++ b/evgMrmApp/src/evgMrm.cpp
@@ -458,7 +458,8 @@ evgMrm::process_inp_cb(CALLBACK *pCallback) {
 void
 evgMrm::postSoftSecondsSrc()
 {
-    setEvtCode(0x7d);
+    // MRF_EVENT_TS_COUNTER_RST event is sent by TimeStampSource::Impl::runSrc()
+    // before this hook is called.
     tickSecond();
     scanIoRequest(ioScanTimestamp);
 }


### PR DESCRIPTION
@mdavidsaver , I tested and it works, the `PpsInp-Sel` with `Sys Clk` was sending 2 x 125 event every second. We generally do not use the `Sys Clk` so I just noticed this recently. Please, have a look.