### PR TITLE
feat: allow clockTS to be lower than the RF clk.

### DIFF
--- a/evrMrmApp/src/drvem.cpp
+++ b/evrMrmApp/src/drvem.cpp
@@ -738,7 +738,7 @@ EVRMRM::clockTS() const
     double eclk=clock();
 
     if( (src!=TSSourceInternal) ||
-       ((src==TSSourceInternal) && (stampClock>eclk)))
+       ((src==TSSourceInternal) && (stampClock > 0)))
         return stampClock;
 
     epicsUInt16 div=tsDiv();


### PR DESCRIPTION
In some scenarios, one would like to set the lower frequency for the timestamp calculations that the RF. I think it is not necessary to limit the user just to the higher frequencies. @mdavidsaver is there any reason you blocked that?