### PR TITLE
fix: add Time-I and make var "next" second to point to the next second

### DIFF
--- a/evgMrmApp/Db/evgMrm.db
+++ b/evgMrmApp/Db/evgMrm.db
@@ -83,6 +83,7 @@ record(longout, "$(P)SendEvt-SP") {
 }
 
 record (stringin, "$(P)Timestamp-RB") {
+  field(DESC, "Next Second Time (+1s)")
   field(DTYP, "Obj Prop string")
   field(INP , "@OBJ=$(OBJ), PROP=NextSecond")
   field(SCAN, "I/O Intr")
@@ -112,6 +113,13 @@ record(bo, "$(P)SoftTickSecond-Cmd") {
 record(ai, "$(P)TimeErr-I") {
   field(DTYP, "Obj Prop double")
   field(INP , "@OBJ=$(OBJ), PROP=Time Error")
+  field(FLNK, "$(P)Time-I")
+}
+
+record (stringin, "$(P)Time-I") {
+  field(DESC, "Actual Time")
+  field(DTYP, "Obj Prop string")
+  field(INP , "@OBJ=$(OBJ), PROP=CurrentSecond")
 }
 
 record(bo,"$(P)SyncTimestamp-Cmd" ) {

--- a/evgMrmApp/src/evg.cpp
+++ b/evgMrmApp/src/evg.cpp
@@ -69,6 +69,10 @@ OBJECT_BEGIN(evgMrm) {
       std::string (evgMrm::*getter)() const = &evgMrm::nextSecond;
       OBJECT_PROP1("NextSecond", getter);
     }
+    {
+      std::string (evgMrm::*getter)() const = &evgMrm::currentSecond;
+      OBJECT_PROP1("CurrentSecond", getter);
+    }
     OBJECT_PROP1("SoftTick", &evgMrm::postSoftSecondsSrc);
     {
       double (evgMrm::*getter)() const = &evgMrm::deltaSeconds;

--- a/evrApp/Db/evrbase.db
+++ b/evrApp/Db/evrbase.db
@@ -442,6 +442,7 @@ record(longin, "$(P)Time$(s=:)Div-I") {
 # reflect the reset of the sub-seconds counter, and will never have nsec==0.
 #
 record(stringin, "$(P)Time-I") {
+  field(DESC, "Actual Time")
   field(DTYP, "EVR Timestamp")
   field(INP , "@OBJ=$(OBJ), Code=$(EVNT1HZ=125)")
   field(SCAN, "Event")

--- a/mrmShared/src/mrmtimesrc.cpp
+++ b/mrmShared/src/mrmtimesrc.cpp
@@ -172,15 +172,16 @@ void TimeStampSource::tickSecond()
 
         /* delay re-sync request until 1Hz is stable, valid system time is available */
         if(ok && valid && impl->resync)  {
-            impl->next = ts.secPastEpoch+POSIX_TIME_AT_EPICS_EPOCH+1;
+            impl->next = ts.secPastEpoch+POSIX_TIME_AT_EPICS_EPOCH;
             impl->resync = false;
         }
+
+        impl->next++;
 
         if(ok) {
             tosend = impl->next;
         }
 
-        impl->next++;
         ok &= tosend!=0;
 
         if(ok && valid) {


### PR DESCRIPTION
This PR corrects two issues:
1) Moves `impl->next++;` before `tosend = impl->next;`, so `next` does not keep the actual time + 2 seconds. It was visible within `Timestamp-RB` PV.
2) Adds the actual time with `Time-I` PV - the same suffix as in case of the EVRs.